### PR TITLE
Issue/#4128 configurable rate limit

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "files.exclude": {
+    "**/.classpath": true,
+    "**/.project": true,
+    "**/.settings": true,
+    "**/target": true,
+    "**/.factorypath": true
+  }
+}

--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitRepository.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitRepository.java
@@ -27,7 +27,6 @@ import io.reactivex.functions.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;

--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/DefaultRateLimitService.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/DefaultRateLimitService.java
@@ -19,7 +19,6 @@ import io.gravitee.repository.ratelimit.api.RateLimitRepository;
 import io.gravitee.repository.ratelimit.api.RateLimitService;
 import io.gravitee.repository.ratelimit.model.RateLimit;
 import io.reactivex.Single;
-import io.reactivex.functions.Function;
 
 import java.util.function.Supplier;
 

--- a/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/QuotaPolicy.java
+++ b/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/QuotaPolicy.java
@@ -159,14 +159,11 @@ public class QuotaPolicy {
     }
 
     private long evaluateActualLimit(ExecutionContext executionContext, QuotaConfiguration quotaConfiguration) {
-        if (quotaConfiguration.getTemplatableLimit() == null) {
+        // use legacy limit if the new limit that supports templates is not defined
+        if (quotaConfiguration.getTemplatableLimit() == null || quotaConfiguration.getTemplatableLimit().isEmpty()) {
             return quotaConfiguration.getLimit();
         } else {
-            try {
-                return Long.parseLong(quotaConfiguration.getTemplatableLimit());
-            } catch (NumberFormatException nfe) {
-                return executionContext.getTemplateEngine().getValue(quotaConfiguration.getTemplatableLimit(), Long.class);
-            }
+            return executionContext.getTemplateEngine().getValue(quotaConfiguration.getTemplatableLimit(), Long.class);
         }
     }
 

--- a/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaConfiguration.java
+++ b/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaConfiguration.java
@@ -26,10 +26,11 @@ public class QuotaConfiguration {
 
     private long limit;
 
+    private String templatableLimit;
+
     private long periodTime;
 
     private ChronoUnit periodTimeUnit;
-//    private TimeUnit periodTimeUnit;
 
     public long getLimit() {
         return limit;
@@ -38,6 +39,15 @@ public class QuotaConfiguration {
     public void setLimit(long limit) {
         this.limit = limit;
     }
+
+    public String getTemplatableLimit() {
+        return templatableLimit;
+    }
+
+    public void setTemplatableLimit(String templatableLimit) {
+        this.templatableLimit = templatableLimit;
+    }
+
 
     public long getPeriodTime() {
         return periodTime;

--- a/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaConfiguration.java
+++ b/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaConfiguration.java
@@ -16,7 +16,6 @@
 package io.gravitee.policy.quota.configuration;
 
 import java.time.temporal.ChronoUnit;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)

--- a/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaConfiguration.java
+++ b/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaConfiguration.java
@@ -23,30 +23,21 @@ import java.time.temporal.ChronoUnit;
  */
 public class QuotaConfiguration {
 
-    private long limit;
-
-    private String templatableLimit;
+    private String limit;
 
     private long periodTime;
 
     private ChronoUnit periodTimeUnit;
 
-    public long getLimit() {
+    private String key;
+
+    public String getLimit() {
         return limit;
     }
 
-    public void setLimit(long limit) {
+    public void setLimit(String limit) {
         this.limit = limit;
     }
-
-    public String getTemplatableLimit() {
-        return templatableLimit;
-    }
-
-    public void setTemplatableLimit(String templatableLimit) {
-        this.templatableLimit = templatableLimit;
-    }
-
 
     public long getPeriodTime() {
         return periodTime;
@@ -62,5 +53,13 @@ public class QuotaConfiguration {
 
     public void setPeriodTimeUnit(ChronoUnit periodTimeUnit) {
         this.periodTimeUnit = periodTimeUnit;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
     }
 }

--- a/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfiguration.java
+++ b/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfiguration.java
@@ -27,6 +27,8 @@ public class QuotaPolicyConfiguration implements PolicyConfiguration {
 
     private boolean addHeaders = true;
 
+    private String key;
+
     private QuotaConfiguration quota;
 
     public QuotaConfiguration getQuota() {
@@ -51,5 +53,13 @@ public class QuotaPolicyConfiguration implements PolicyConfiguration {
 
     public void setAddHeaders(boolean addHeaders) {
         this.addHeaders = addHeaders;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
     }
 }

--- a/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfiguration.java
+++ b/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfiguration.java
@@ -27,8 +27,6 @@ public class QuotaPolicyConfiguration implements PolicyConfiguration {
 
     private boolean addHeaders = true;
 
-    private String key;
-
     private QuotaConfiguration quota;
 
     public QuotaConfiguration getQuota() {
@@ -53,13 +51,5 @@ public class QuotaPolicyConfiguration implements PolicyConfiguration {
 
     public void setAddHeaders(boolean addHeaders) {
         this.addHeaders = addHeaders;
-    }
-
-    public String getKey() {
-        return key;
-    }
-
-    public void setKey(String key) {
-        this.key = key;
     }
 }

--- a/gravitee-policy-quota/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-quota/src/main/resources/schemas/schema-form.json
@@ -14,15 +14,26 @@
       "title": "Add response headers",
       "description": "Add X-Quota-Limit, X-Quota-Remaining and X-Quota-Reset headers in HTTP response"
     },
+    "key": {
+      "type": "string",
+      "default": "",
+      "title": "Key",
+      "description": "Key to identify a consumer against which the rate-limiting will be applied. Leave it empty to use the default behavior (plan/subscription pair). Supports SpEL."
+    },
     "quota" : {
       "type" : "object",
       "title": "Apply quota",
       "id" : "urn:jsonschema:io:gravitee:policy:quota:configuration:QuotaConfiguration",
       "properties" : {
-        "limit" : {
+        "limit": {
           "type" : "integer",
+          "title": "(Legacy) Fixed max requests",
+          "description": "Fixed limit on the number of requests that can be sent."
+        },
+        "templatableLimit" : {
+          "type" : "string",
           "title": "Max requests",
-          "description": "Limit on the number of requests that can be sent."
+          "description": "Limit on the number of requests that can be sent. If defined, overrides Fixed max requests. Supports SpEL."
         },
         "periodTime" : {
           "type" : "integer",

--- a/gravitee-policy-quota/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-quota/src/main/resources/schemas/schema-form.json
@@ -14,26 +14,21 @@
       "title": "Add response headers",
       "description": "Add X-Quota-Limit, X-Quota-Remaining and X-Quota-Reset headers in HTTP response"
     },
-    "key": {
-      "type": "string",
-      "default": "",
-      "title": "Key",
-      "description": "Key to identify a consumer against which the rate-limiting will be applied. Leave it empty to use the default behavior (plan/subscription pair). Supports SpEL."
-    },
     "quota" : {
       "type" : "object",
       "title": "Apply quota",
       "id" : "urn:jsonschema:io:gravitee:policy:quota:configuration:QuotaConfiguration",
       "properties" : {
-        "limit": {
-          "type" : "integer",
-          "title": "(Legacy) Fixed max requests",
-          "description": "Fixed limit on the number of requests that can be sent."
+        "key": {
+          "type": "string",
+          "default": "",
+          "title": "Key",
+          "description": "Key to identify a consumer against whom the quota will be applied. Leave it empty to use the default behavior (plan/subscription pair). Supports SpEL."
         },
-        "templatableLimit" : {
+        "limit": {
           "type" : "string",
           "title": "Max requests",
-          "description": "Limit on the number of requests that can be sent. If defined, overrides Fixed max requests. Supports SpEL."
+          "description": "Limit on the number of requests that can be sent. Supports SpEL."
         },
         "periodTime" : {
           "type" : "integer",

--- a/gravitee-policy-quota/src/test/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfigurationTest.java
+++ b/gravitee-policy-quota/src/test/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfigurationTest.java
@@ -42,6 +42,7 @@ public class QuotaPolicyConfigurationTest {
 
         Assert.assertNotNull(configuration.getQuota());
         Assert.assertEquals(10, configuration.getQuota().getLimit());
+        Assert.assertEquals("10", configuration.getQuota().getTemplatableLimit());
         Assert.assertEquals(10, configuration.getQuota().getPeriodTime());
         Assert.assertEquals(ChronoUnit.MINUTES, configuration.getQuota().getPeriodTimeUnit());
     }
@@ -54,7 +55,9 @@ public class QuotaPolicyConfigurationTest {
         Assert.assertNotNull(configuration);
         Assert.assertFalse(configuration.isAddHeaders());
         Assert.assertTrue(configuration.isAsync());
-    }
+    }   
+    
+    // TODO test on old format (no templatableLimit)
 
     private <T> T load(String resource, Class<T> type) throws IOException {
         URL jsonFile = this.getClass().getResource(resource);

--- a/gravitee-policy-quota/src/test/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfigurationTest.java
+++ b/gravitee-policy-quota/src/test/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfigurationTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.URL;
 import java.time.temporal.ChronoUnit;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -55,9 +54,7 @@ public class QuotaPolicyConfigurationTest {
         Assert.assertNotNull(configuration);
         Assert.assertFalse(configuration.isAddHeaders());
         Assert.assertTrue(configuration.isAsync());
-    }   
-    
-    // TODO test on old format (no templatableLimit)
+    }
 
     private <T> T load(String resource, Class<T> type) throws IOException {
         URL jsonFile = this.getClass().getResource(resource);

--- a/gravitee-policy-quota/src/test/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfigurationTest.java
+++ b/gravitee-policy-quota/src/test/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfigurationTest.java
@@ -40,8 +40,7 @@ public class QuotaPolicyConfigurationTest {
         Assert.assertFalse(configuration.isAsync());
 
         Assert.assertNotNull(configuration.getQuota());
-        Assert.assertEquals(10, configuration.getQuota().getLimit());
-        Assert.assertEquals("10", configuration.getQuota().getTemplatableLimit());
+        Assert.assertEquals("10", configuration.getQuota().getLimit());
         Assert.assertEquals(10, configuration.getQuota().getPeriodTime());
         Assert.assertEquals(ChronoUnit.MINUTES, configuration.getQuota().getPeriodTimeUnit());
     }

--- a/gravitee-policy-quota/src/test/resources/io/gravitee/policy/quota/configuration/quota01.json
+++ b/gravitee-policy-quota/src/test/resources/io/gravitee/policy/quota/configuration/quota01.json
@@ -1,6 +1,7 @@
 {
   "quota": {
     "limit": 10,
+    "templatableLimit": "10",
     "periodTime": 10,
     "periodTimeUnit": "MINUTES"
   }

--- a/gravitee-policy-quota/src/test/resources/io/gravitee/policy/quota/configuration/quota01.json
+++ b/gravitee-policy-quota/src/test/resources/io/gravitee/policy/quota/configuration/quota01.json
@@ -1,7 +1,6 @@
 {
   "quota": {
-    "limit": 10,
-    "templatableLimit": "10",
+    "limit": "10",
     "periodTime": 10,
     "periodTimeUnit": "MINUTES"
   }

--- a/gravitee-policy-quota/src/test/resources/io/gravitee/policy/quota/configuration/quota02.json
+++ b/gravitee-policy-quota/src/test/resources/io/gravitee/policy/quota/configuration/quota02.json
@@ -3,6 +3,7 @@
   "async": true,
   "quota": {
     "limit": 10,
+    "templatableLimit": "10",
     "periodTime": 10,
     "periodTimeUnit": "MINUTES"
   }

--- a/gravitee-policy-quota/src/test/resources/io/gravitee/policy/quota/configuration/quota02.json
+++ b/gravitee-policy-quota/src/test/resources/io/gravitee/policy/quota/configuration/quota02.json
@@ -2,8 +2,7 @@
   "addHeaders": false,
   "async": true,
   "quota": {
-    "limit": 10,
-    "templatableLimit": "10",
+    "limit": "10",
     "periodTime": 10,
     "periodTimeUnit": "MINUTES"
   }

--- a/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/RateLimitPolicy.java
+++ b/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/RateLimitPolicy.java
@@ -94,8 +94,10 @@ public class RateLimitPolicy {
             return;
         }
 
+        String key = createRateLimitKey(request, executionContext, rateLimitPolicyConfiguration);
+
         RateLimitConfiguration rateLimitConfiguration = rateLimitPolicyConfiguration.getRate();
-        String key = createRateLimitKey(request, executionContext);
+        Long limit = evaluateActualLimit(executionContext, rateLimitConfiguration);
 
         Context context = Vertx.currentContext();
 
@@ -111,7 +113,7 @@ public class RateLimitPolicy {
 
                         RateLimit rate = new RateLimit(key);
                         rate.setCounter(0);
-                        rate.setLimit(rateLimitConfiguration.getLimit());
+                        rate.setLimit(limit);
                         rate.setResetTime(resetTimeMillis);
                         rate.setSubscription((String) executionContext.getAttribute(ExecutionContext.ATTR_SUBSCRIPTION_ID));
                         return rate;
@@ -128,15 +130,15 @@ public class RateLimitPolicy {
                     public void onSuccess(RateLimit rateLimit) {
                         // Set Rate Limit headers on response
                         if (rateLimitPolicyConfiguration.isAddHeaders()) {
-                            response.headers().set(X_RATE_LIMIT_LIMIT, Long.toString(rateLimitConfiguration.getLimit()));
-                            response.headers().set(X_RATE_LIMIT_REMAINING, Long.toString(Math.max(0, rateLimitConfiguration.getLimit() - rateLimit.getCounter())));
+                            response.headers().set(X_RATE_LIMIT_LIMIT, Long.toString(limit));
+                            response.headers().set(X_RATE_LIMIT_REMAINING, Long.toString(Math.max(0, limit - rateLimit.getCounter())));
                             response.headers().set(X_RATE_LIMIT_RESET, Long.toString(rateLimit.getResetTime()));
                         }
 
-                        if (rateLimit.getCounter() <= rateLimitConfiguration.getLimit()) {
+                        if (rateLimit.getCounter() <= limit) {
                             policyChain.doNext(request, response);
                         } else {
-                            policyChain.failWith(createLimitExceeded(rateLimitConfiguration));
+                            policyChain.failWith(createLimitExceeded(rateLimitConfiguration, limit));
                         }
                     }
 
@@ -144,9 +146,9 @@ public class RateLimitPolicy {
                     public void onError(Throwable throwable) {
                         // Set Rate Limit headers on response
                         if (rateLimitPolicyConfiguration.isAddHeaders()) {
-                            response.headers().set(X_RATE_LIMIT_LIMIT, Long.toString(rateLimitConfiguration.getLimit()));
+                            response.headers().set(X_RATE_LIMIT_LIMIT, Long.toString(limit));
                             // We don't know about the remaining calls, let's assume it is the same as the limit
-                            response.headers().set(X_RATE_LIMIT_REMAINING, Long.toString(rateLimitConfiguration.getLimit()));
+                            response.headers().set(X_RATE_LIMIT_REMAINING, Long.toString(limit));
                             response.headers().set(X_RATE_LIMIT_RESET, Long.toString(-1));
                         }
 
@@ -156,19 +158,37 @@ public class RateLimitPolicy {
                 });
     }
 
-    private String createRateLimitKey(Request request, ExecutionContext executionContext) {
+    private long evaluateActualLimit(ExecutionContext executionContext, RateLimitConfiguration rateLimitConfiguration) {
+        if (rateLimitConfiguration.getTemplatableLimit() == null) {
+            return rateLimitConfiguration.getLimit();
+        } else {
+            try {
+                return Long.parseLong(rateLimitConfiguration.getTemplatableLimit());
+            } catch (NumberFormatException nfe) {
+                return executionContext.getTemplateEngine().getValue(rateLimitConfiguration.getTemplatableLimit(), Long.class);
+            }
+        }
+    }
+
+    private String createRateLimitKey(Request request, ExecutionContext executionContext, RateLimitPolicyConfiguration rateLimitPolicyConfiguration) {
         // Rate limit key must contain :
-        // 1_ PLAN_ID
-        // 1_ SUBSCRIPTION_ID
+        // 1_ User-defined key, or (PLAN_ID, SUBSCRIPTION_ID) by default
         // 2_ Rate Type (rate-limit / quota)
         // 3_ RESOLVED_PATH (policy attached to a path rather than a plan)
         String resolvedPath = (String) executionContext.getAttribute(ExecutionContext.ATTR_RESOLVED_PATH);
 
-        StringBuilder key = new StringBuilder((String) executionContext.getAttribute(ExecutionContext.ATTR_PLAN))
+        StringBuilder key = new StringBuilder();
+
+        if (rateLimitPolicyConfiguration.getKey() == null || rateLimitPolicyConfiguration.getKey().isEmpty()) {
+            key.append(executionContext.getAttribute(ExecutionContext.ATTR_PLAN))
                 .append(KEY_SEPARATOR)
-                .append((String) executionContext.getAttribute(ExecutionContext.ATTR_SUBSCRIPTION_ID))
-                .append(KEY_SEPARATOR)
-                .append(RATE_LIMIT_TYPE);
+                .append(executionContext.getAttribute(ExecutionContext.ATTR_SUBSCRIPTION_ID));
+        } else {
+            key.append(executionContext.getTemplateEngine().getValue(rateLimitPolicyConfiguration.getKey(), String.class));
+        }
+
+        key.append(KEY_SEPARATOR)
+            .append(RATE_LIMIT_TYPE);
 
         if (resolvedPath != null) {
             key.append(KEY_SEPARATOR).append(resolvedPath.hashCode());
@@ -177,15 +197,15 @@ public class RateLimitPolicy {
         return key.toString();
     }
 
-    private PolicyResult createLimitExceeded(RateLimitConfiguration rateLimitConfiguration) {
+    private PolicyResult createLimitExceeded(RateLimitConfiguration rateLimitConfiguration, long actualLimit) {
         return PolicyResult.failure(
                 RATE_LIMIT_TOO_MANY_REQUESTS,
                 HttpStatusCode.TOO_MANY_REQUESTS_429,
-                "Rate limit exceeded ! You reach the limit of " + rateLimitConfiguration.getLimit() +
+                "Rate limit exceeded ! You reach the limit of " + actualLimit +
                         " requests per " + rateLimitConfiguration.getPeriodTime() + ' ' +
                         rateLimitConfiguration.getPeriodTimeUnit().name().toLowerCase(),
                 Maps.<String, Object>builder()
-                        .put("limit", rateLimitConfiguration.getLimit())
+                        .put("limit", actualLimit)
                         .put("period_time", rateLimitConfiguration.getPeriodTime())
                         .put("period_unit", rateLimitConfiguration.getPeriodTimeUnit())
                         .build());

--- a/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/RateLimitPolicy.java
+++ b/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/RateLimitPolicy.java
@@ -36,6 +36,8 @@ import io.vertx.reactivex.RxHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Supplier;
 
 /**
@@ -55,7 +57,7 @@ public class RateLimitPolicy {
         PARSE_LONG,
         SPEL_TEMPLATE
     }
-    private LimitEvaluationMethod limitEvaluationMethod = LimitEvaluationMethod.PARSE_LONG;
+    private static Map<RateLimitConfiguration, LimitEvaluationMethod> limitEvaluationMethods = new HashMap<>();
 
     /**
      * LOGGER
@@ -96,6 +98,10 @@ public class RateLimitPolicy {
     public void onRequest(Request request, Response response, ExecutionContext executionContext, PolicyChain policyChain) {
         RateLimitService rateLimitService = executionContext.getComponent(RateLimitService.class);
         RateLimitConfiguration rateLimitConfiguration = rateLimitPolicyConfiguration.getRate();
+
+        if (!limitEvaluationMethods.containsKey(rateLimitConfiguration)) {
+            limitEvaluationMethods.put(rateLimitConfiguration, LimitEvaluationMethod.PARSE_LONG);
+        }
 
         if (rateLimitService == null) {
             policyChain.failWith(PolicyResult.failure("No rate-limit service has been installed."));
@@ -165,12 +171,12 @@ public class RateLimitPolicy {
     }
 
     private long evaluateActualLimit(ExecutionContext executionContext, RateLimitConfiguration rateLimitConfiguration) {
-        if (limitEvaluationMethod == LimitEvaluationMethod.PARSE_LONG) {
+        if (limitEvaluationMethods.get(rateLimitConfiguration) == LimitEvaluationMethod.PARSE_LONG) {
             try {
                 return Long.parseLong(rateLimitConfiguration.getLimit());
             } catch (NumberFormatException nfe) {
                 // store the limit evaluation method to avoid creating an exception stack every time
-                limitEvaluationMethod = LimitEvaluationMethod.SPEL_TEMPLATE;
+                limitEvaluationMethods.put(rateLimitConfiguration, LimitEvaluationMethod.SPEL_TEMPLATE);
                 return executionContext.getTemplateEngine().getValue(rateLimitConfiguration.getLimit(), Long.class);
             }
         } else {

--- a/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/RateLimitPolicy.java
+++ b/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/RateLimitPolicy.java
@@ -168,27 +168,33 @@ public class RateLimitPolicy {
     }
 
     private String createRateLimitKey(Request request, ExecutionContext executionContext, RateLimitPolicyConfiguration rateLimitPolicyConfiguration) {
-        // Rate limit key must contain :
-        // 1_ User-defined key, or (PLAN_ID, SUBSCRIPTION_ID) by default
-        // 2_ Rate Type (rate-limit / quota)
-        // 3_ RESOLVED_PATH (policy attached to a path rather than a plan)
+        // Rate limit key contains the following:
+        // 1_ (PLAN_ID, SUBSCRIPTION_ID) pair, note that for keyless plans this is evaluated to (1, CLIENT_IP)
+        // 2_ User-defined key, if it exists
+        // 3_ Rate Type (rate-limit / quota)
+        // 4_ RESOLVED_PATH (policy attached to a path rather than a plan)
         String resolvedPath = (String) executionContext.getAttribute(ExecutionContext.ATTR_RESOLVED_PATH);
 
         StringBuilder key = new StringBuilder();
 
-        if (rateLimitPolicyConfiguration.getKey() == null || rateLimitPolicyConfiguration.getKey().isEmpty()) {
-            key.append(executionContext.getAttribute(ExecutionContext.ATTR_PLAN))
+        key
+            .append(executionContext.getAttribute(ExecutionContext.ATTR_PLAN))
+            .append(executionContext.getAttribute(ExecutionContext.ATTR_SUBSCRIPTION_ID));
+
+        if (rateLimitPolicyConfiguration.getKey() != null && !rateLimitPolicyConfiguration.getKey().isEmpty()) {
+            key
                 .append(KEY_SEPARATOR)
-                .append(executionContext.getAttribute(ExecutionContext.ATTR_SUBSCRIPTION_ID));
-        } else {
-            key.append(executionContext.getTemplateEngine().getValue(rateLimitPolicyConfiguration.getKey(), String.class));
+                .append(executionContext.getTemplateEngine().getValue(rateLimitPolicyConfiguration.getKey(), String.class));
         }
 
-        key.append(KEY_SEPARATOR)
+        key
+            .append(KEY_SEPARATOR)
             .append(RATE_LIMIT_TYPE);
 
         if (resolvedPath != null) {
-            key.append(KEY_SEPARATOR).append(resolvedPath.hashCode());
+            key
+                .append(KEY_SEPARATOR)
+                .append(resolvedPath.hashCode());
         }
 
         return key.toString();

--- a/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/RateLimitPolicy.java
+++ b/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/RateLimitPolicy.java
@@ -159,14 +159,11 @@ public class RateLimitPolicy {
     }
 
     private long evaluateActualLimit(ExecutionContext executionContext, RateLimitConfiguration rateLimitConfiguration) {
-        if (rateLimitConfiguration.getTemplatableLimit() == null) {
+        // use legacy limit if the new limit that supports templates is not defined
+        if (rateLimitConfiguration.getTemplatableLimit() == null || rateLimitConfiguration.getTemplatableLimit().isEmpty()) {
             return rateLimitConfiguration.getLimit();
         } else {
-            try {
-                return Long.parseLong(rateLimitConfiguration.getTemplatableLimit());
-            } catch (NumberFormatException nfe) {
-                return executionContext.getTemplateEngine().getValue(rateLimitConfiguration.getTemplatableLimit(), Long.class);
-            }
+            return executionContext.getTemplateEngine().getValue(rateLimitConfiguration.getTemplatableLimit(), Long.class);
         }
     }
 

--- a/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/configuration/RateLimitConfiguration.java
+++ b/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/configuration/RateLimitConfiguration.java
@@ -25,6 +25,8 @@ public class RateLimitConfiguration {
 
     private long limit;
 
+    private String templatableLimit;
+
     private long periodTime;
 
     private TimeUnit periodTimeUnit;
@@ -35,6 +37,14 @@ public class RateLimitConfiguration {
 
     public void setLimit(long limit) {
         this.limit = limit;
+    }
+
+    public String getTemplatableLimit() {
+        return templatableLimit;
+    }
+
+    public void setTemplatableLimit(String templatableLimit) {
+        this.templatableLimit = templatableLimit;
     }
 
     public long getPeriodTime() {

--- a/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/configuration/RateLimitConfiguration.java
+++ b/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/configuration/RateLimitConfiguration.java
@@ -23,28 +23,20 @@ import java.util.concurrent.TimeUnit;
  */
 public class RateLimitConfiguration {
 
-    private long limit;
-
-    private String templatableLimit;
+    private String limit;
 
     private long periodTime;
 
     private TimeUnit periodTimeUnit;
 
-    public long getLimit() {
+    private String key;
+
+    public String getLimit() {
         return limit;
     }
 
-    public void setLimit(long limit) {
+    public void setLimit(String limit) {
         this.limit = limit;
-    }
-
-    public String getTemplatableLimit() {
-        return templatableLimit;
-    }
-
-    public void setTemplatableLimit(String templatableLimit) {
-        this.templatableLimit = templatableLimit;
     }
 
     public long getPeriodTime() {
@@ -61,5 +53,13 @@ public class RateLimitConfiguration {
 
     public void setPeriodTimeUnit(TimeUnit periodTimeUnit) {
         this.periodTimeUnit = periodTimeUnit;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
     }
 }

--- a/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfiguration.java
+++ b/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfiguration.java
@@ -27,6 +27,8 @@ public class RateLimitPolicyConfiguration implements PolicyConfiguration {
 
     private boolean addHeaders;
 
+    private String key;
+
     private RateLimitConfiguration rate;
 
     public RateLimitConfiguration getRate() {
@@ -52,4 +54,13 @@ public class RateLimitPolicyConfiguration implements PolicyConfiguration {
     public void setAddHeaders(boolean addHeaders) {
         this.addHeaders = addHeaders;
     }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
 }

--- a/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfiguration.java
+++ b/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfiguration.java
@@ -27,8 +27,6 @@ public class RateLimitPolicyConfiguration implements PolicyConfiguration {
 
     private boolean addHeaders;
 
-    private String key;
-
     private RateLimitConfiguration rate;
 
     public RateLimitConfiguration getRate() {
@@ -53,14 +51,6 @@ public class RateLimitPolicyConfiguration implements PolicyConfiguration {
 
     public void setAddHeaders(boolean addHeaders) {
         this.addHeaders = addHeaders;
-    }
-
-    public String getKey() {
-        return key;
-    }
-
-    public void setKey(String key) {
-        this.key = key;
     }
 
 }

--- a/gravitee-policy-ratelimit/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-ratelimit/src/main/resources/schemas/schema-form.json
@@ -14,15 +14,26 @@
       "title": "Add response headers",
       "description": "Add X-Rate-Limit-Limit, X-Rate-Limit-Remaining and X-Rate-Limit-Reset headers in HTTP response"
     },
+    "key": {
+      "type": "string",
+      "default": "",
+      "title": "Key",
+      "description": "Key to identify a consumer against which the rate-limiting will be applied. Leave it empty to use the default behavior (plan/subscription pair). Supports SpEL."
+    },
     "rate" : {
       "type" : "object",
       "title": "Apply rate-limiting",
       "id" : "urn:jsonschema:io:gravitee:policy:ratelimit:configuration:RateLimitConfiguration",
       "properties" : {
-        "limit" : {
+        "limit": {
           "type" : "integer",
+          "title": "(Legacy) Fixed max requests",
+          "description": "Fixed limit on the number of requests that can be sent."
+        },
+        "templatableLimit" : {
+          "type" : "string",
           "title": "Max requests",
-          "description": "Limit on the number of requests that can be sent."
+          "description": "Limit on the number of requests that can be sent. If defined, overrides Fixed max requests. Supports SpEL."
         },
         "periodTime" : {
           "type" : "integer",

--- a/gravitee-policy-ratelimit/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-ratelimit/src/main/resources/schemas/schema-form.json
@@ -14,26 +14,21 @@
       "title": "Add response headers",
       "description": "Add X-Rate-Limit-Limit, X-Rate-Limit-Remaining and X-Rate-Limit-Reset headers in HTTP response"
     },
-    "key": {
-      "type": "string",
-      "default": "",
-      "title": "Key",
-      "description": "Key to identify a consumer against which the rate-limiting will be applied. Leave it empty to use the default behavior (plan/subscription pair). Supports SpEL."
-    },
     "rate" : {
       "type" : "object",
       "title": "Apply rate-limiting",
       "id" : "urn:jsonschema:io:gravitee:policy:ratelimit:configuration:RateLimitConfiguration",
       "properties" : {
-        "limit": {
-          "type" : "integer",
-          "title": "(Legacy) Fixed max requests",
-          "description": "Fixed limit on the number of requests that can be sent."
+        "key": {
+          "type": "string",
+          "default": "",
+          "title": "Key",
+          "description": "Key to identify a consumer against whom the rate-limiting will be applied. Leave it empty to use the default behavior (plan/subscription pair). Supports SpEL."
         },
-        "templatableLimit" : {
+        "limit" : {
           "type" : "string",
           "title": "Max requests",
-          "description": "Limit on the number of requests that can be sent. If defined, overrides Fixed max requests. Supports SpEL."
+          "description": "Limit on the number of requests that can be sent. Supports SpEL."
         },
         "periodTime" : {
           "type" : "integer",

--- a/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/RateLimitPolicyTest.java
+++ b/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/RateLimitPolicyTest.java
@@ -83,7 +83,7 @@ public class RateLimitPolicyTest {
 
         policyChain = spy(PolicyChain.class);
 
-        rateLimitConfiguration.setLimit(1);
+        rateLimitConfiguration.setLimit("1");
         rateLimitConfiguration.setPeriodTime(1);
         rateLimitConfiguration.setPeriodTimeUnit(TimeUnit.SECONDS);
         policyConfiguration.setRate(rateLimitConfiguration);
@@ -108,7 +108,7 @@ public class RateLimitPolicyTest {
         RateLimitPolicyConfiguration policyConfiguration = new RateLimitPolicyConfiguration();
         RateLimitConfiguration rateLimitConfiguration = new RateLimitConfiguration();
 
-        rateLimitConfiguration.setLimit(10);
+        rateLimitConfiguration.setLimit("10");
         rateLimitConfiguration.setPeriodTime(10);
         rateLimitConfiguration.setPeriodTimeUnit(TimeUnit.SECONDS);
         policyConfiguration.setRate(rateLimitConfiguration);
@@ -156,7 +156,7 @@ public class RateLimitPolicyTest {
 
         int limit = 10;
 
-        rateLimitConfiguration.setLimit(limit);
+        rateLimitConfiguration.setLimit(Integer.toString(limit));
         rateLimitConfiguration.setPeriodTime(10);
         rateLimitConfiguration.setPeriodTimeUnit(TimeUnit.SECONDS);
         policyConfiguration.setRate(rateLimitConfiguration);
@@ -198,67 +198,6 @@ public class RateLimitPolicyTest {
         inOrder.verify(policyChain, times(limit)).doNext(request, response);
         inOrder.verify(policyChain, times(exceedCalls)).failWith(any(PolicyResult.class));
     }
-
-    
-    @Test
-    public void multipleRequestsTemplatableLimitFixed() throws InterruptedException {
-        final HttpHeaders headers = new HttpHeaders();
-        headers.setAll(new HashMap<String, String>() {
-            {
-                put(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
-                put(X_GRAVITEE_API_NAME, API_NAME_HEADER_VALUE);
-            }
-        });
-
-        RateLimitPolicyConfiguration policyConfiguration = new RateLimitPolicyConfiguration();
-        RateLimitConfiguration rateLimitConfiguration = new RateLimitConfiguration();
-
-        int limit = 10;
-
-        rateLimitConfiguration.setLimit(15);
-        rateLimitConfiguration.setTemplatableLimit(Long.toString(limit));
-        rateLimitConfiguration.setPeriodTime(10);
-        rateLimitConfiguration.setPeriodTimeUnit(TimeUnit.SECONDS);
-        policyConfiguration.setRate(rateLimitConfiguration);
-
-        RateLimitPolicy rateLimitPolicy = new RateLimitPolicy(policyConfiguration);
-
-        when(executionContext.getComponent(RateLimitService.class)).thenReturn(rateLimitService);
-
-        int calls = 15;
-        int exceedCalls = calls - limit;
-
-        final CountDownLatch latch = new CountDownLatch(calls);
-
-        policyChain = spy(new PolicyChain() {
-            @Override
-            public void doNext(Request request, Response response) {
-                latch.countDown();
-            }
-
-            @Override
-            public void failWith(PolicyResult policyResult) {
-                latch.countDown();
-            }
-
-            @Override
-            public void streamFailWith(PolicyResult policyResult) {
-
-            }
-        });
-
-        InOrder inOrder = inOrder(policyChain);
-
-        for (int i = 0 ; i < calls ; i++) {
-            rateLimitPolicy.onRequest(request, response, executionContext, policyChain);
-        }
-
-        Assert.assertTrue(latch.await(10000, TimeUnit.MILLISECONDS));
-
-        inOrder.verify(policyChain, times(limit)).doNext(request, response);
-        inOrder.verify(policyChain, times(exceedCalls)).failWith(any(PolicyResult.class));
-    }
-
 
     @Test
     public void multipleRequestsTemplatableLimitExpression() throws InterruptedException {
@@ -275,8 +214,7 @@ public class RateLimitPolicyTest {
 
         int limit = 10;
 
-        rateLimitConfiguration.setLimit(15);
-        rateLimitConfiguration.setTemplatableLimit("{(2*5)}");
+        rateLimitConfiguration.setLimit("{(2*5)}");
         rateLimitConfiguration.setPeriodTime(10);
         rateLimitConfiguration.setPeriodTimeUnit(TimeUnit.SECONDS);
         policyConfiguration.setRate(rateLimitConfiguration);

--- a/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfigurationTest.java
+++ b/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfigurationTest.java
@@ -41,6 +41,7 @@ public class RateLimitPolicyConfigurationTest {
 
         Assert.assertNotNull(configuration.getRate());
         Assert.assertEquals(10, configuration.getRate().getLimit());
+        Assert.assertEquals("10", configuration.getRate().getTemplatableLimit());
         Assert.assertEquals(10, configuration.getRate().getPeriodTime());
         Assert.assertEquals(TimeUnit.MINUTES, configuration.getRate().getPeriodTimeUnit());
     }
@@ -54,6 +55,8 @@ public class RateLimitPolicyConfigurationTest {
         Assert.assertTrue(configuration.isAddHeaders());
         Assert.assertTrue(configuration.isAsync());
     }
+
+    // TODO test on old format (no templatableLimit)
 
     private <T> T load(String resource, Class<T> type) throws IOException {
         URL jsonFile = this.getClass().getResource(resource);

--- a/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfigurationTest.java
+++ b/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfigurationTest.java
@@ -56,8 +56,6 @@ public class RateLimitPolicyConfigurationTest {
         Assert.assertTrue(configuration.isAsync());
     }
 
-    // TODO test on old format (no templatableLimit)
-
     private <T> T load(String resource, Class<T> type) throws IOException {
         URL jsonFile = this.getClass().getResource(resource);
         return new ObjectMapper().readValue(jsonFile, type);

--- a/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfigurationTest.java
+++ b/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfigurationTest.java
@@ -40,8 +40,7 @@ public class RateLimitPolicyConfigurationTest {
         Assert.assertFalse(configuration.isAsync());
 
         Assert.assertNotNull(configuration.getRate());
-        Assert.assertEquals(10, configuration.getRate().getLimit());
-        Assert.assertEquals("10", configuration.getRate().getTemplatableLimit());
+        Assert.assertEquals("10", configuration.getRate().getLimit());
         Assert.assertEquals(10, configuration.getRate().getPeriodTime());
         Assert.assertEquals(TimeUnit.MINUTES, configuration.getRate().getPeriodTimeUnit());
     }

--- a/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit01.json
+++ b/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit01.json
@@ -1,6 +1,7 @@
 {
   "rate": {
     "limit": 10,
+    "templatableLimit": "10",
     "periodTime": 10,
     "periodTimeUnit": "MINUTES"
   }

--- a/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit01.json
+++ b/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit01.json
@@ -1,7 +1,6 @@
 {
   "rate": {
-    "limit": 10,
-    "templatableLimit": "10",
+    "limit": "10",
     "periodTime": 10,
     "periodTimeUnit": "MINUTES"
   }

--- a/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit02.json
+++ b/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit02.json
@@ -3,6 +3,7 @@
   "async": true,
   "rate": {
     "limit": 10,
+    "templatableLimit": "10",
     "periodTime": 10,
     "periodTimeUnit": "MINUTES"
   }

--- a/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit02.json
+++ b/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit02.json
@@ -2,8 +2,7 @@
   "addHeaders": true,
   "async": true,
   "rate": {
-    "limit": 10,
-    "templatableLimit": "10",
+    "limit": "10",
     "periodTime": 10,
     "periodTimeUnit": "MINUTES"
   }


### PR DESCRIPTION
As promised, here is a pull request for gravitee-io/issues#4128 :slightly_smiling_face: 

We would like your opinion on the way we handled the switch to configurability of limit value. Because of change from `long` to `string` it was not possible to keep the existing model, so we considered several options:

- change type of the existing property :arrow_right: that would break repositories I believe, and not sure that we want a migration script for a minor feature
- add a new property and hide the existing one from the UI, but keep it in repositories :arrow_right: the former rate limit is not displayed and nothing is displayed instead, so existing systems work but the UI lies to users
- add a second property along with the existing one, with priority to the new one if defined :arrow_right: safe, but makes the UI kind of weird, even with some explanation text
- do some magic with getters to have one visible property with two backing field :arrow_right: we tried that but could not make it work, I assume some of the layers use the fields directly

We went with option 3 but maybe you can think of something else, or another option has your preference.