### PR TITLE
a switch in limit policy

### DIFF
--- a/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/configuration/RateLimitConfiguration.java
+++ b/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/configuration/RateLimitConfiguration.java
@@ -23,6 +23,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class RateLimitConfiguration {
 
+    private boolean subscriptionLimit;
+
     private long limit;
 
     private String dynamicLimit;
@@ -32,6 +34,14 @@ public class RateLimitConfiguration {
     private TimeUnit periodTimeUnit;
 
     private String key;
+
+    public boolean isSubscriptionLimit() {
+        return subscriptionLimit;
+    }
+
+    public void setSubscriptionLimit(boolean subscriptionLimit) {
+        this.subscriptionLimit = subscriptionLimit;
+    }
 
     public long getLimit() {
         return limit;

--- a/gravitee-policy-ratelimit/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-ratelimit/src/main/resources/schemas/schema-form.json
@@ -28,6 +28,12 @@
             "expression-language": true
           }
         },
+        "subscriptionLimit": {
+          "type": "boolean",
+          "default": true,
+          "title": "limit on subscription",
+          "description": "By activating this option, rate-limiting is applied to every separate subscription, else is applied to all plan subscriptions for this API."
+        },
         "limit" : {
           "type" : "integer",
           "title": "Max requests (static)",

--- a/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfigurationTest.java
+++ b/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfigurationTest.java
@@ -40,6 +40,7 @@ public class RateLimitPolicyConfigurationTest {
         Assert.assertFalse(configuration.isAsync());
 
         Assert.assertNotNull(configuration.getRate());
+        Assert.assertTrue(configuration.getRate().isSubscriptionLimit());
         Assert.assertEquals(10, configuration.getRate().getLimit());
         Assert.assertEquals("{(2*5)}", configuration.getRate().getDynamicLimit());
         Assert.assertEquals(10, configuration.getRate().getPeriodTime());

--- a/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit01.json
+++ b/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit01.json
@@ -1,5 +1,6 @@
 {
   "rate": {
+    "subscriptionLimit": true,
     "limit": 10,
     "dynamicLimit": "{(2*5)}",
     "periodTime": 10,

--- a/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit02.json
+++ b/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit02.json
@@ -2,6 +2,7 @@
   "addHeaders": true,
   "async": true,
   "rate": {
+    "subscriptionLimit": true,
     "limit": 10,
     "periodTime": 10,
     "periodTimeUnit": "MINUTES"

--- a/gravitee-policy-spikearrest/src/main/java/io/gravitee/policy/spike/SpikeArrestPolicy.java
+++ b/gravitee-policy-spikearrest/src/main/java/io/gravitee/policy/spike/SpikeArrestPolicy.java
@@ -165,38 +165,33 @@ public class SpikeArrestPolicy {
 
     private String createRateLimitKey(Request request, ExecutionContext executionContext, SpikeArrestConfiguration spikeArrestConfiguration) {
         // Rate limit key contains the following:
-        // 1_ (API_ID, PLAN_ID) pair, note that for keyless plans this is evaluated to (API_ID, 1)
+        // 1_ If active option subscriptionLimit:
+        // (PLAN_ID, SUBSCRIPTION_ID) pair, note that for keyless plans this is evaluated to (1, CLIENT_IP),
+        // else (API_ID, PLAN_ID) pair, note that for keyless plans this is evaluated to (API_ID, 1)
         // 2_ User-defined key, if it exists
         // 3_ Rate Type set to spike-arrest
         // 4_ RESOLVED_PATH (policy attached to a path rather than a plan)
         String resolvedPath = (String) executionContext.getAttribute(ExecutionContext.ATTR_RESOLVED_PATH);
 
         StringBuilder key = new StringBuilder();
-
-        String plan = (String)executionContext.getAttribute(ExecutionContext.ATTR_PLAN);
-        if (plan != null) {
-            key
-                    .append(executionContext.getAttribute(ExecutionContext.ATTR_PLAN))
+        if (spikeArrestConfiguration.isSubscriptionLimit()) {
+            key.append(executionContext.getAttribute(ExecutionContext.ATTR_PLAN))
                     .append(executionContext.getAttribute(ExecutionContext.ATTR_SUBSCRIPTION_ID));
-        } else if (executionContext.getAttributes().containsKey(ATTR_OAUTH_CLIENT_ID)) { // TODO manage also APIKey when managed by K8S plugins
-            key
-                    .append(executionContext.getAttribute(ATTR_OAUTH_CLIENT_ID));
         } else {
-            key.append(executionContext.getAttribute(ExecutionContext.ATTR_API));
+            key.append(executionContext.getAttribute(ExecutionContext.ATTR_API))
+                    .append(executionContext.getAttribute(ExecutionContext.ATTR_PLAN));
         }
 
         if (spikeArrestConfiguration.getKey() != null && !spikeArrestConfiguration.getKey().isEmpty()) {
-            key
-                .append(KEY_SEPARATOR)
-                .append(executionContext.getTemplateEngine().getValue(spikeArrestConfiguration.getKey(), String.class));
+            key.append(KEY_SEPARATOR)
+                    .append(executionContext.getTemplateEngine().getValue(spikeArrestConfiguration.getKey(), String.class));
         }
 
         key.append(KEY_SEPARATOR).append(RATE_LIMIT_TYPE);
 
         if (resolvedPath != null) {
-            key
-                .append(KEY_SEPARATOR)
-                .append(resolvedPath.hashCode());
+            key.append(KEY_SEPARATOR)
+                    .append(resolvedPath.hashCode());
         }
 
         return key.toString();

--- a/gravitee-policy-spikearrest/src/main/java/io/gravitee/policy/spike/configuration/SpikeArrestConfiguration.java
+++ b/gravitee-policy-spikearrest/src/main/java/io/gravitee/policy/spike/configuration/SpikeArrestConfiguration.java
@@ -23,6 +23,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class SpikeArrestConfiguration {
 
+    private boolean subscriptionLimit;
+
     private long limit;
 
     private String dynamicLimit;
@@ -32,6 +34,14 @@ public class SpikeArrestConfiguration {
     private TimeUnit periodTimeUnit;
 
     private String key;
+
+    public boolean isSubscriptionLimit() {
+        return subscriptionLimit;
+    }
+
+    public void setSubscriptionLimit(boolean subscriptionLimit) {
+        this.subscriptionLimit = subscriptionLimit;
+    }
 
     public String getKey() {
         return key;

--- a/gravitee-policy-spikearrest/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-spikearrest/src/main/resources/schemas/schema-form.json
@@ -28,6 +28,12 @@
             "expression-language": true
           }
         },
+        "subscriptionLimit": {
+          "type": "boolean",
+          "default": true,
+          "title": "limit on subscription",
+          "description": "By activating this option, rate-limiting is applied to every separate subscription, else is applied to all plan subscriptions for this API."
+        },
         "limit" : {
           "type" : "integer",
           "title": "Max requests (static)",

--- a/gravitee-policy-spikearrest/src/test/java/io/gravitee/policy/spike/configuration/SpikeArrestPolicyConfigurationTest.java
+++ b/gravitee-policy-spikearrest/src/test/java/io/gravitee/policy/spike/configuration/SpikeArrestPolicyConfigurationTest.java
@@ -40,6 +40,7 @@ public class SpikeArrestPolicyConfigurationTest {
         Assert.assertFalse(configuration.isAsync());
 
         Assert.assertNotNull(configuration.getSpike());
+        Assert.assertTrue(configuration.getSpike().isSubscriptionLimit());
         Assert.assertEquals(10, configuration.getSpike().getLimit());
         Assert.assertEquals(10, configuration.getSpike().getPeriodTime());
         Assert.assertEquals(TimeUnit.MINUTES, configuration.getSpike().getPeriodTimeUnit());

--- a/gravitee-policy-spikearrest/src/test/resources/io/gravitee/policy/spike/configuration/spikearrest01.json
+++ b/gravitee-policy-spikearrest/src/test/resources/io/gravitee/policy/spike/configuration/spikearrest01.json
@@ -1,5 +1,6 @@
 {
   "spike": {
+    "subscriptionLimit": true,
     "limit": 10,
     "periodTime": 10,
     "periodTimeUnit": "MINUTES"

--- a/gravitee-policy-spikearrest/src/test/resources/io/gravitee/policy/spike/configuration/spikearrest02.json
+++ b/gravitee-policy-spikearrest/src/test/resources/io/gravitee/policy/spike/configuration/spikearrest02.json
@@ -2,6 +2,7 @@
   "addHeaders": true,
   "async": true,
   "spike": {
+    "subscriptionLimit": true,
     "dynamicLimit": "10",
     "periodTime": 10,
     "periodTimeUnit": "MINUTES"


### PR DESCRIPTION
Add a switch between the restriction for each subscription and for all subscriptions within the plan in rate-limit and spike-arrest policies.
I am making a pull request based on an agreement in a gitter correspondence. Correspondence has been added to the issue comments.