### PR TITLE
chore: bump apim repository to 3.12.0

### DIFF
--- a/gravitee-gateway-services-ratelimit/pom.xml
+++ b/gravitee-gateway-services-ratelimit/pom.xml
@@ -38,8 +38,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
         </dependency>
 
         <dependency>

--- a/gravitee-policy-quota/pom.xml
+++ b/gravitee-policy-quota/pom.xml
@@ -48,8 +48,8 @@
             <artifactId>gravitee-policy-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.gravitee.common</groupId>

--- a/gravitee-policy-ratelimit/pom.xml
+++ b/gravitee-policy-ratelimit/pom.xml
@@ -46,8 +46,8 @@
             <artifactId>gravitee-policy-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.gravitee.common</groupId>

--- a/gravitee-policy-spikearrest/pom.xml
+++ b/gravitee-policy-spikearrest/pom.xml
@@ -46,8 +46,8 @@
             <artifactId>gravitee-policy-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.gravitee.common</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <gravitee-bom.version>1.1</gravitee-bom.version>
         <gravitee-gateway-api.version>1.20.1</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.6.0</gravitee-policy-api.version>
-        <gravitee-repository-api.version>1.30.9</gravitee-repository-api.version>
+        <gravitee-apim-repository-api.version>3.12.0</gravitee-apim-repository-api.version>
         <gravitee-common.version>1.16.2</gravitee-common.version>
         <gravitee-node.version>1.5.0</gravitee-node.version>
     </properties>
@@ -77,9 +77,9 @@
             </dependency>
 
             <dependency>
-                <groupId>io.gravitee.repository</groupId>
-                <artifactId>gravitee-repository</artifactId>
-                <version>${gravitee-repository-api.version}</version>
+                <groupId>io.gravitee.apim.repository</groupId>
+                <artifactId>gravitee-apim-repository-api</artifactId>
+                <version>${gravitee-apim-repository-api.version}</version>
                 <scope>provided</scope>
             </dependency>
 


### PR DESCRIPTION
gravitee-io/issues#6040