### PR TITLE
refactor: configure async repository remote cache timeout

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -135,6 +135,11 @@ This policy does not prevent request spikes.
   }
 ----
 
+==== Policy configuration
+
+The following property can be set to configure the policy `services.ratelimit.timeout`.
+The "timeout" value refers to the default time (in milliseconds) that the system will wait for a response when attempting to access data from the data source. If the data source does not respond within the allotted time, the system will stop waiting and assume that the data source is not available.
+
 === Spike Arrest
 
 The Spike-Arrest policy configures the number of requests allow over a limited period of time (from seconds to minutes).

--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitRepository.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitRepository.java
@@ -79,55 +79,42 @@ public class AsyncRateLimitRepository implements RateLimitRepository<RateLimit> 
 
     void merge() {
         if (!keys.isEmpty()) {
-            keys.forEach(
-                new java.util.function.Consumer<String>() {
-                    @Override
-                    public void accept(String key) {
-                        lock(key)
-                            // By default, delay signal are done through the computation scheduler
-                            //        .observeOn(Schedulers.computation())
-                            .andThen(
-                                localCacheRateLimitRepository
-                                    .get(key)
-                                    // Remote rate is incremented by the local counter value
-                                    // If the remote does not contains existing value, use the local counter
-                                    .flatMapSingle(
-                                        (Function<LocalRateLimit, SingleSource<RateLimit>>) localRateLimit ->
-                                            remoteCacheRateLimitRepository.incrementAndGet(
-                                                key,
-                                                localRateLimit.getLocal(),
-                                                () -> localRateLimit
-                                            )
-                                    )
-                                    .zipWith(
-                                        localCacheRateLimitRepository.get(key),
-                                        new BiFunction<RateLimit, LocalRateLimit, LocalRateLimit>() {
-                                            @Override
-                                            public LocalRateLimit apply(RateLimit rateLimit, LocalRateLimit localRateLimit)
-                                                throws Exception {
-                                                // Set the counter with the latest value from the repository
-                                                localRateLimit.setCounter(rateLimit.getCounter());
-
-                                                // Re-init the local counter
-                                                localRateLimit.setLocal(0L);
-
-                                                return localRateLimit;
-                                            }
-                                        }
-                                    )
-                                    // And save the new counter value into the local cache
-                                    .flatMapSingle(
-                                        (Function<LocalRateLimit, SingleSource<LocalRateLimit>>) rateLimit ->
-                                            localCacheRateLimitRepository.save(rateLimit)
-                                    )
-                                    .doAfterTerminate(() -> unlock(key))
-                                    .doOnError(throwable ->
-                                        logger.error("An unexpected error occurs while refreshing asynchronous rate-limit", throwable)
-                                    )
+            keys.forEach(key ->
+                lock(key)
+                    // By default, delay signal are done through the computation scheduler
+                    //        .observeOn(Schedulers.computation())
+                    .andThen(
+                        localCacheRateLimitRepository
+                            .get(key)
+                            // Remote rate is incremented by the local counter value
+                            // If the remote does not contains existing value, use the local counter
+                            .flatMapSingle(
+                                (Function<LocalRateLimit, SingleSource<RateLimit>>) localRateLimit ->
+                                    remoteCacheRateLimitRepository.incrementAndGet(key, localRateLimit.getLocal(), () -> localRateLimit)
                             )
-                            .subscribe();
-                    }
-                }
+                            .zipWith(
+                                localCacheRateLimitRepository.get(key),
+                                (rateLimit, localRateLimit) -> {
+                                    // Set the counter with the latest value from the repository
+                                    localRateLimit.setCounter(rateLimit.getCounter());
+
+                                    // Re-init the local counter
+                                    localRateLimit.setLocal(0L);
+
+                                    return localRateLimit;
+                                }
+                            )
+                            // And save the new counter value into the local cache
+                            .flatMapSingle(
+                                (Function<LocalRateLimit, SingleSource<LocalRateLimit>>) rateLimit ->
+                                    localCacheRateLimitRepository.save(rateLimit)
+                            )
+                            .doAfterTerminate(() -> unlock(key))
+                            .doOnError(throwable ->
+                                logger.error("An unexpected error occurs while refreshing asynchronous rate-limit", throwable)
+                            )
+                    )
+                    .subscribe()
             );
 
             // Clear keys

--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitService.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitService.java
@@ -37,6 +37,9 @@ public class AsyncRateLimitService extends AbstractService {
     @Value("${services.ratelimit.enabled:true}")
     private boolean enabled;
 
+    @Value("${services.ratelimit.timeout:100}")
+    private long timeout;
+
     @Override
     protected void doStart() throws Exception {
         super.doStart();
@@ -64,16 +67,12 @@ public class AsyncRateLimitService extends AbstractService {
             asyncRateLimitRepository.initialize();
 
             LOGGER.info("Register the rate-limit service bridge for synchronous and asynchronous mode");
-            DefaultRateLimitService rateLimitService = new DefaultRateLimitService();
-            rateLimitService.setRateLimitRepository(rateLimitRepository);
-            rateLimitService.setAsyncRateLimitRepository(asyncRateLimitRepository);
+            DefaultRateLimitService rateLimitService = new DefaultRateLimitService(rateLimitRepository, asyncRateLimitRepository, timeout);
             parentBeanFactory.registerSingleton(RateLimitService.class.getName(), rateLimitService);
         } else {
             // By disabling async and cached rate limiting, only the strict mode is allowed
             LOGGER.info("Register the rate-limit service bridge for strict mode only");
-            DefaultRateLimitService rateLimitService = new DefaultRateLimitService();
-            rateLimitService.setRateLimitRepository(rateLimitRepository);
-            rateLimitService.setAsyncRateLimitRepository(rateLimitRepository);
+            DefaultRateLimitService rateLimitService = new DefaultRateLimitService(rateLimitRepository, rateLimitRepository, timeout);
             parentBeanFactory.registerSingleton(RateLimitService.class.getName(), rateLimitService);
         }
     }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-990

**Description**

Here we want to allow users to manage the timeout between the system and the datasource for this policy. It can be useful when want to decrease it if the connection with the data source is lost for example.

⚠️ Commits cherry picked from here 👉🏼 https://github.com/gravitee-io/gravitee-policy-ratelimit/pull/78

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-APIM-990-ratelimit-timetout-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/2.0.1-APIM-990-ratelimit-timetout-master-SNAPSHOT/gravitee-ratelimit-parent-2.0.1-APIM-990-ratelimit-timetout-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
