### PR TITLE
refactor: configure async repository remote cache timeout

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -135,6 +135,11 @@ This policy does not prevent request spikes.
   }
 ----
 
+==== Policy configuration
+
+The following property can be set to configure the policy `services.ratelimit.timeout`.
+The "timeout" value refers to the default time (in milliseconds) that the system will wait for a response when attempting to access data from the data source. If the data source does not respond within the allotted time, the system will stop waiting and assume that the data source is not available.
+
 === Spike Arrest
 
 The Spike-Arrest policy configures the number of requests allow over a limited period of time (from seconds to minutes).

--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitService.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitService.java
@@ -37,6 +37,9 @@ public class AsyncRateLimitService extends AbstractService {
     @Value("${services.ratelimit.enabled:true}")
     private boolean enabled;
 
+    @Value("${services.ratelimit.timeout:100}")
+    private long timeout;
+
     @Override
     protected void doStart() throws Exception {
         super.doStart();
@@ -64,16 +67,12 @@ public class AsyncRateLimitService extends AbstractService {
             asyncRateLimitRepository.initialize();
 
             LOGGER.info("Register the rate-limit service bridge for synchronous and asynchronous mode");
-            DefaultRateLimitService rateLimitService = new DefaultRateLimitService();
-            rateLimitService.setRateLimitRepository(rateLimitRepository);
-            rateLimitService.setAsyncRateLimitRepository(asyncRateLimitRepository);
+            DefaultRateLimitService rateLimitService = new DefaultRateLimitService(rateLimitRepository, asyncRateLimitRepository, timeout);
             parentBeanFactory.registerSingleton(RateLimitService.class.getName(), rateLimitService);
         } else {
             // By disabling async and cached rate limiting, only the strict mode is allowed
             LOGGER.info("Register the rate-limit service bridge for strict mode only");
-            DefaultRateLimitService rateLimitService = new DefaultRateLimitService();
-            rateLimitService.setRateLimitRepository(rateLimitRepository);
-            rateLimitService.setAsyncRateLimitRepository(rateLimitRepository);
+            DefaultRateLimitService rateLimitService = new DefaultRateLimitService(rateLimitRepository, rateLimitRepository, timeout);
             parentBeanFactory.registerSingleton(RateLimitService.class.getName(), rateLimitService);
         }
     }

--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/DefaultRateLimitService.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/DefaultRateLimitService.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.ratelimit.api.RateLimitRepository;
 import io.gravitee.repository.ratelimit.api.RateLimitService;
 import io.gravitee.repository.ratelimit.model.RateLimit;
 import io.reactivex.Single;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 /**
@@ -29,6 +30,17 @@ public class DefaultRateLimitService implements RateLimitService {
 
     private RateLimitRepository<RateLimit> rateLimitRepository;
     private RateLimitRepository<RateLimit> asyncRateLimitRepository;
+    private long timeout;
+
+    public DefaultRateLimitService(
+        RateLimitRepository<RateLimit> rateLimitRepository,
+        RateLimitRepository<RateLimit> asyncRateLimitRepository,
+        long timeout
+    ) {
+        this.rateLimitRepository = rateLimitRepository;
+        this.asyncRateLimitRepository = asyncRateLimitRepository;
+        this.timeout = timeout;
+    }
 
     private RateLimitRepository<RateLimit> getRateLimitRepository(boolean async) {
         return (async) ? asyncRateLimitRepository : rateLimitRepository;
@@ -38,22 +50,17 @@ public class DefaultRateLimitService implements RateLimitService {
         return asyncRateLimitRepository;
     }
 
-    public void setAsyncRateLimitRepository(RateLimitRepository<RateLimit> asyncRateLimitRepository) {
-        this.asyncRateLimitRepository = asyncRateLimitRepository;
-    }
-
     public RateLimitRepository getRateLimitRepository() {
         return rateLimitRepository;
-    }
-
-    public void setRateLimitRepository(RateLimitRepository<RateLimit> rateLimitRepository) {
-        this.rateLimitRepository = rateLimitRepository;
     }
 
     @Override
     public Single<RateLimit> incrementAndGet(String key, long weight, boolean async, Supplier<RateLimit> supplier) {
         try {
-            return getRateLimitRepository(async).incrementAndGet(key, weight, supplier).map(rateLimit -> rateLimit);
+            return getRateLimitRepository(async)
+                .incrementAndGet(key, weight, supplier)
+                .timeout(timeout, TimeUnit.MILLISECONDS)
+                .map(rateLimit -> rateLimit);
         } catch (Exception ex) {
             return Single.error(ex);
         }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-990

**Description**

Here we want to allow users to manage the timeout between the system and the datasource for this policy. It can be useful when want to decrease it if the connection with the data source is lost for example.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.15.1-APIM-990-ratelimit-timetout-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/1.15.1-APIM-990-ratelimit-timetout-SNAPSHOT/gravitee-ratelimit-parent-1.15.1-APIM-990-ratelimit-timetout-SNAPSHOT.zip)
  <!-- Version placeholder end -->
