### PR TITLE
refactor: clean schema-form to make them compatible with gio-form-json-schema component

### DIFF
--- a/gravitee-policy-quota/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-quota/src/main/resources/schemas/schema-form.json
@@ -1,66 +1,60 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:quota:configuration:QuotaPolicyConfiguration",
-  "properties" : {
-    "async": {
-      "type": "boolean",
-      "default": false,
-      "title": "Non-strict mode (async)",
-      "description": "By activating this option, quota is applied in an asynchronous way meaning that the distributed counter value is not strict."
-    },
-    "addHeaders": {
-      "type": "boolean",
-      "default": true,
-      "title": "Add response headers",
-      "description": "Add X-Quota-Limit, X-Quota-Remaining and X-Quota-Reset headers in HTTP response"
-    },
-    "quota" : {
-      "type" : "object",
-      "title": "Apply quota",
-      "id" : "urn:jsonschema:io:gravitee:policy:quota:configuration:QuotaConfiguration",
-      "properties" : {
-        "key": {
-          "type": "string",
-          "default": "",
-          "title": "Key",
-          "description": "Key to identify a consumer against whom the quota will be applied. Leave it empty to use the default behavior (plan/subscription pair). Supports EL.",
-          "x-schema-form": {
-            "expression-language": true
-          }
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "async": {
+            "type": "boolean",
+            "default": false,
+            "title": "Non-strict mode (async)",
+            "description": "By activating this option, quota is applied in an asynchronous way meaning that the distributed counter value is not strict."
         },
-        "limit" : {
-          "type" : "integer",
-          "title": "Max requests (static)",
-          "description": "Static limit on the number of requests that can be sent (this limit is used if the value > 0).",
-          "minimum": 0
+        "addHeaders": {
+            "type": "boolean",
+            "default": true,
+            "title": "Add response headers",
+            "description": "Add X-Quota-Limit, X-Quota-Remaining and X-Quota-Reset headers in HTTP response"
         },
-        "dynamicLimit" : {
-          "type" : "string",
-          "title": "Max requests (dynamic)",
-          "description": "Dynamic limit on the number of requests that can be sent (this limit is used if static limit = 0). The dynamic value is based on EL expressions.",
-          "x-schema-form": {
-            "expression-language": true
-          }
-        },
-        "periodTime" : {
-          "type" : "integer",
-          "title": "Time duration",
-          "default": 1
-        },
-        "periodTimeUnit" : {
-          "type" : "string",
-          "title": "Time unit",
-          "default": "MONTHS",
-          "enum" : [ "HOURS", "DAYS", "WEEKS", "MONTHS" ]
+        "quota": {
+            "type": "object",
+            "title": "Apply quota",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "default": "",
+                    "title": "Key",
+                    "description": "Key to identify a consumer against whom the quota will be applied. Leave it empty to use the default behavior (plan/subscription pair). Supports EL.",
+                    "x-schema-form": {
+                        "expression-language": true
+                    }
+                },
+                "limit": {
+                    "type": "integer",
+                    "title": "Max requests (static)",
+                    "description": "Static limit on the number of requests that can be sent (this limit is used if the value > 0).",
+                    "minimum": 0
+                },
+                "dynamicLimit": {
+                    "type": "string",
+                    "title": "Max requests (dynamic)",
+                    "description": "Dynamic limit on the number of requests that can be sent (this limit is used if static limit = 0). The dynamic value is based on EL expressions.",
+                    "x-schema-form": {
+                        "expression-language": true
+                    }
+                },
+                "periodTime": {
+                    "type": "integer",
+                    "title": "Time duration",
+                    "default": 1
+                },
+                "periodTimeUnit": {
+                    "type": "string",
+                    "title": "Time unit",
+                    "default": "MONTHS",
+                    "enum": ["HOURS", "DAYS", "WEEKS", "MONTHS"]
+                }
+            },
+            "required": ["periodTime", "periodTimeUnit"]
         }
-      },
-      "required": [
-        "periodTime",
-        "periodTimeUnit"
-      ]
-    }
-  },
-  "required": [
-    "quota"
-  ]
+    },
+    "required": ["quota"]
 }

--- a/gravitee-policy-ratelimit/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-ratelimit/src/main/resources/schemas/schema-form.json
@@ -1,66 +1,60 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:ratelimit:configuration:RateLimitPolicyConfiguration",
-  "properties" : {
-    "async": {
-      "type": "boolean",
-      "default": false,
-      "title": "Non-strict mode (async)",
-      "description": "By activating this option, rate-limiting is applied in an asynchronous way meaning that the distributed counter value is not strict."
-    },
-    "addHeaders": {
-      "type": "boolean",
-      "default": false,
-      "title": "Add response headers",
-      "description": "Add X-Rate-Limit-Limit, X-Rate-Limit-Remaining and X-Rate-Limit-Reset headers in HTTP response"
-    },
-    "rate" : {
-      "type" : "object",
-      "title": "Apply rate-limiting",
-      "id" : "urn:jsonschema:io:gravitee:policy:ratelimit:configuration:RateLimitConfiguration",
-      "properties" : {
-        "key": {
-          "type": "string",
-          "default": "",
-          "title": "Key",
-          "description": "Key to identify a consumer against whom the rate-limiting will be applied. Leave it empty to use the default behavior (plan/subscription pair). Supports EL.",
-          "x-schema-form": {
-            "expression-language": true
-          }
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "async": {
+            "type": "boolean",
+            "default": false,
+            "title": "Non-strict mode (async)",
+            "description": "By activating this option, rate-limiting is applied in an asynchronous way meaning that the distributed counter value is not strict."
         },
-        "limit" : {
-          "type" : "integer",
-          "title": "Max requests (static)",
-          "description": "Static limit on the number of requests that can be sent (this limit is used if the value > 0).",
-          "minimum": 0
+        "addHeaders": {
+            "type": "boolean",
+            "default": false,
+            "title": "Add response headers",
+            "description": "Add X-Rate-Limit-Limit, X-Rate-Limit-Remaining and X-Rate-Limit-Reset headers in HTTP response"
         },
-        "dynamicLimit" : {
-          "type" : "string",
-          "title": "Max requests (dynamic)",
-          "description": "Dynamic limit on the number of requests that can be sent (this limit is used if static limit = 0). The dynamic value is based on EL expressions.",
-          "x-schema-form": {
-            "expression-language": true
-          }
-        },
-        "periodTime" : {
-          "type" : "integer",
-          "title": "Time duration",
-          "default": 1
-        },
-        "periodTimeUnit" : {
-          "type" : "string",
-          "title": "Time unit",
-          "default": "SECONDS",
-          "enum" : [ "SECONDS", "MINUTES" ]
+        "rate": {
+            "type": "object",
+            "title": "Apply rate-limiting",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "default": "",
+                    "title": "Key",
+                    "description": "Key to identify a consumer against whom the rate-limiting will be applied. Leave it empty to use the default behavior (plan/subscription pair). Supports EL.",
+                    "x-schema-form": {
+                        "expression-language": true
+                    }
+                },
+                "limit": {
+                    "type": "integer",
+                    "title": "Max requests (static)",
+                    "description": "Static limit on the number of requests that can be sent (this limit is used if the value > 0).",
+                    "minimum": 0
+                },
+                "dynamicLimit": {
+                    "type": "string",
+                    "title": "Max requests (dynamic)",
+                    "description": "Dynamic limit on the number of requests that can be sent (this limit is used if static limit = 0). The dynamic value is based on EL expressions.",
+                    "x-schema-form": {
+                        "expression-language": true
+                    }
+                },
+                "periodTime": {
+                    "type": "integer",
+                    "title": "Time duration",
+                    "default": 1
+                },
+                "periodTimeUnit": {
+                    "type": "string",
+                    "title": "Time unit",
+                    "default": "SECONDS",
+                    "enum": ["SECONDS", "MINUTES"]
+                }
+            },
+            "required": ["periodTime", "periodTimeUnit"]
         }
-      },
-      "required": [
-        "periodTime",
-        "periodTimeUnit"
-      ]
-    }
-  },
-  "required": [
-    "rate"
-  ]
+    },
+    "required": ["rate"]
 }

--- a/gravitee-policy-spikearrest/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-spikearrest/src/main/resources/schemas/schema-form.json
@@ -1,66 +1,60 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:spike:configuration:SpikeArrestPolicyConfiguration",
-  "properties" : {
-    "async": {
-      "type": "boolean",
-      "default": false,
-      "title": "Non-strict mode (async)",
-      "description": "By activating this option, spike limit is applied in an asynchronous way meaning that the distributed counter value is not strict."
-    },
-    "addHeaders": {
-      "type": "boolean",
-      "default": false,
-      "title": "Add response headers",
-      "description": "Add X-Spike-Arrest-Limit, X-Spike-Arrest-Remaining and X-Spike-Arrest-Reset headers in HTTP response"
-    },
-    "spike" : {
-      "type" : "object",
-      "title": "Apply spike limit",
-      "id" : "urn:jsonschema:io:gravitee:policy:spike:configuration:SpikeArrestConfiguration",
-      "properties" : {
-        "key": {
-          "type": "string",
-          "default": "",
-          "title": "Key",
-          "description": "Key to identify a consumer against whom the quota will be applied. Leave it empty to use the default behavior. Supports EL.",
-          "x-schema-form": {
-            "expression-language": true
-          }
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "async": {
+            "type": "boolean",
+            "default": false,
+            "title": "Non-strict mode (async)",
+            "description": "By activating this option, spike limit is applied in an asynchronous way meaning that the distributed counter value is not strict."
         },
-        "limit" : {
-          "type" : "integer",
-          "title": "Max requests (static)",
-          "description": "Static limit on the number of requests that can be sent (this limit is used if the value > 0).",
-          "minimum": 0
+        "addHeaders": {
+            "type": "boolean",
+            "default": false,
+            "title": "Add response headers",
+            "description": "Add X-Spike-Arrest-Limit, X-Spike-Arrest-Remaining and X-Spike-Arrest-Reset headers in HTTP response"
         },
-        "dynamicLimit" : {
-          "type" : "string",
-          "title": "Max requests (dynamic)",
-          "description": "Dynamic limit on the number of requests that can be sent (this limit is used if static limit = 0). The dynamic value is based on EL expressions.",
-          "x-schema-form": {
-            "expression-language": true
-          }
-        },
-        "periodTime" : {
-          "type" : "integer",
-          "title": "Time duration",
-          "default": 1
-        },
-        "periodTimeUnit" : {
-          "type" : "string",
-          "title": "Time unit",
-          "default": "SECONDS",
-          "enum" : [ "SECONDS", "MINUTES" ]
+        "spike": {
+            "type": "object",
+            "title": "Apply spike limit",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "default": "",
+                    "title": "Key",
+                    "description": "Key to identify a consumer against whom the quota will be applied. Leave it empty to use the default behavior. Supports EL.",
+                    "x-schema-form": {
+                        "expression-language": true
+                    }
+                },
+                "limit": {
+                    "type": "integer",
+                    "title": "Max requests (static)",
+                    "description": "Static limit on the number of requests that can be sent (this limit is used if the value > 0).",
+                    "minimum": 0
+                },
+                "dynamicLimit": {
+                    "type": "string",
+                    "title": "Max requests (dynamic)",
+                    "description": "Dynamic limit on the number of requests that can be sent (this limit is used if static limit = 0). The dynamic value is based on EL expressions.",
+                    "x-schema-form": {
+                        "expression-language": true
+                    }
+                },
+                "periodTime": {
+                    "type": "integer",
+                    "title": "Time duration",
+                    "default": 1
+                },
+                "periodTimeUnit": {
+                    "type": "string",
+                    "title": "Time unit",
+                    "default": "SECONDS",
+                    "enum": ["SECONDS", "MINUTES"]
+                }
+            },
+            "required": ["periodTime", "periodTimeUnit"]
         }
-      },
-      "required": [
-        "periodTime",
-        "periodTimeUnit"
-      ]
-    }
-  },
-  "required": [
-    "spike"
-  ]
+    },
+    "required": ["spike"]
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-748

**Description**

Update schema-form to make them compatible with the new gio-form-json-schema component.

to validate these changes it is necessary that it works with the old and the new  UI component 
and also with backend rest-api check

 Old :
 Online checker : https://gravitee-io-labs.github.io/gravitee-schema-form-checker/
 
 New :
 Online checker : https://particles.gravitee.io/?path=/story/components-form-json-schema--string


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/2.0.1-json-schema-SNAPSHOT/gravitee-ratelimit-parent-2.0.1-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
