### PR TITLE
feat(quota): Add support for the next minute / next hour / next day, …

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -84,6 +84,26 @@ This policy does not prevent request spikes.
   }
 ----
 
+==== Gateway configuration (gravitee.yml)
+[source, yaml]
+----
+  policy:
+    quota:
+      mode: strict # Or round
+----
+
+If the mode is `strict` then the end of the period for a new quota counter will be based on the request timestamp.
+Example:
+
+ "08/03/2019 22:01:54" will be converted to "08/04/2019 22:01:54" for 1 DAY
+ "08/03/2019 01:14:33" will be converted to "08/03/2019 02:14:33" for 1 HOUR
+
+If the mode is `round` then the end of the period for a new quota counter will be based on the next minute / hour / day (depending on the `periodTimeUnit`).
+Example:
+
+ "08/02/2019 04:01:54" will be converted to "08/03/2019 00:00:00" for 1 DAY
+ "08/03/2019 01:14:33" will be converted to "08/03/2019 02:00:00" for 1 HOUR
+
 === Rate-Limit
 
 The Rate-Limit policy configures the number of requests allow over a limited period of time (from seconds to minutes).

--- a/gravitee-policy-quota/pom.xml
+++ b/gravitee-policy-quota/pom.xml
@@ -85,12 +85,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-rx-java3</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaMode.java
+++ b/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaMode.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.quota.configuration;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public enum QuotaMode {
+    STRICT,
+    ROUND;
+
+    public static QuotaMode get(String str) {
+        for (QuotaMode mode : values()) {
+            if (mode.name().equalsIgnoreCase(str)) {
+                return mode;
+            }
+        }
+
+        return STRICT;
+    }
+}

--- a/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/utils/DateUtils.java
+++ b/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/utils/DateUtils.java
@@ -19,6 +19,8 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Calendar;
+import java.util.TimeZone;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -26,11 +28,72 @@ import java.time.temporal.ChronoUnit;
  */
 public final class DateUtils {
 
-    public static long getEndOfPeriod(long startingTime, long periodTime, ChronoUnit periodTimeUnit) {
+    public static long getEndOfPeriodForStrict(long startingTime, long periodTime, ChronoUnit periodTimeUnit) {
         return ZonedDateTime
             .ofInstant(Instant.ofEpochMilli(startingTime), ZoneId.systemDefault())
             .plus(periodTime, periodTimeUnit)
             .toInstant()
             .toEpochMilli();
+    }
+
+    public static long getEndOfPeriodForRound(long currentTime, long periodTimeIncrement, ChronoUnit periodTimeUnit, String timeZoneId) {
+        if (periodTimeIncrement > Integer.MAX_VALUE || periodTimeIncrement <= 0) {
+            throw new IllegalArgumentException("Invalid period time increment");
+        }
+        Calendar cal = Calendar.getInstance(
+            (timeZoneId == null || timeZoneId.trim().isEmpty()) ? TimeZone.getDefault() : TimeZone.getTimeZone(timeZoneId)
+        );
+        cal.setTimeInMillis(currentTime);
+        cal.clear(Calendar.MILLISECOND);
+        int field;
+        switch (periodTimeUnit) {
+            case YEARS:
+                field = Calendar.YEAR;
+                cal.clear(Calendar.SECOND);
+                cal.clear(Calendar.MINUTE);
+                cal.set(Calendar.HOUR_OF_DAY, 0);
+                cal.set(Calendar.DAY_OF_MONTH, 1);
+                cal.set(Calendar.MONTH, 0);
+                break;
+            case MONTHS:
+                field = Calendar.MONTH;
+                cal.clear(Calendar.SECOND);
+                cal.clear(Calendar.MINUTE);
+                cal.set(Calendar.HOUR_OF_DAY, 0);
+                cal.set(Calendar.DAY_OF_MONTH, 1);
+                break;
+            case WEEKS:
+                field = Calendar.WEEK_OF_YEAR;
+                cal.clear(Calendar.SECOND);
+                cal.clear(Calendar.MINUTE);
+                cal.set(Calendar.HOUR_OF_DAY, 0);
+                cal.set(Calendar.DAY_OF_WEEK, 1);
+                break;
+            case DAYS:
+                field = Calendar.DATE;
+                cal.clear(Calendar.SECOND);
+                cal.clear(Calendar.MINUTE);
+                cal.set(Calendar.HOUR_OF_DAY, 0);
+                break;
+            case HOURS:
+                field = Calendar.HOUR_OF_DAY;
+                cal.clear(Calendar.SECOND);
+                cal.clear(Calendar.MINUTE);
+                break;
+            case MINUTES:
+                field = Calendar.MINUTE;
+                cal.clear(Calendar.SECOND);
+                break;
+            case SECONDS:
+                field = Calendar.SECOND;
+                break;
+            case MILLIS:
+                field = Calendar.MILLISECOND;
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid period time unit");
+        }
+        cal.add(field, (int) periodTimeIncrement);
+        return cal.getTimeInMillis();
     }
 }

--- a/gravitee-policy-quota/src/test/java/io/gravitee/policy/quota/local/LocalCacheQuotaProvider.java
+++ b/gravitee-policy-quota/src/test/java/io/gravitee/policy/quota/local/LocalCacheQuotaProvider.java
@@ -29,7 +29,7 @@ import java.util.function.Supplier;
  */
 public class LocalCacheQuotaProvider implements RateLimitService {
 
-    private ConcurrentMap<Serializable, RateLimit> rateLimits = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Serializable, RateLimit> rateLimits = new ConcurrentHashMap<>();
 
     public void clean() {
         rateLimits.clear();

--- a/gravitee-policy-quota/src/test/java/io/gravitee/policy/quota/utils/DateUtilsTest.java
+++ b/gravitee-policy-quota/src/test/java/io/gravitee/policy/quota/utils/DateUtilsTest.java
@@ -15,8 +15,12 @@
  */
 package io.gravitee.policy.quota.utils;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.*;
 import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,7 +33,7 @@ public class DateUtilsTest {
     @Test
     public void add_one_month() {
         long start = LocalTime.now().atDate(LocalDate.of(2017, Month.AUGUST, 1)).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
-        long end = DateUtils.getEndOfPeriod(start, 1, ChronoUnit.MONTHS);
+        long end = DateUtils.getEndOfPeriodForStrict(start, 1, ChronoUnit.MONTHS);
 
         Assert.assertTrue((end - start) == 2_678_400_000L);
     }
@@ -38,7 +42,7 @@ public class DateUtilsTest {
     public void add_two_months() {
         // From 01/08/2017 to 01/10/2017
         long start = LocalTime.now().atDate(LocalDate.of(2017, Month.AUGUST, 1)).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
-        long end = DateUtils.getEndOfPeriod(start, 2, ChronoUnit.MONTHS);
+        long end = DateUtils.getEndOfPeriodForStrict(start, 2, ChronoUnit.MONTHS);
 
         Assert.assertTrue((end - start) == 2_678_400_000L + 2592_000_000L);
     }
@@ -46,7 +50,7 @@ public class DateUtilsTest {
     @Test
     public void add_one_day() {
         long now = System.currentTimeMillis();
-        long end = DateUtils.getEndOfPeriod(now, 1, ChronoUnit.DAYS);
+        long end = DateUtils.getEndOfPeriodForStrict(now, 1, ChronoUnit.DAYS);
 
         Assert.assertTrue((end - now) == 86_400_000);
     }
@@ -54,8 +58,76 @@ public class DateUtilsTest {
     @Test
     public void add_two_days() {
         long now = System.currentTimeMillis();
-        long end = DateUtils.getEndOfPeriod(now, 2, ChronoUnit.DAYS);
+        long end = DateUtils.getEndOfPeriodForStrict(now, 2, ChronoUnit.DAYS);
 
         Assert.assertTrue((end - now) == 86_400_000 * 2);
+    }
+
+    @Test
+    public void quotaReset_1minute() throws ParseException {
+        testQuotaReset("08/03/2019 02:15:00", "08/03/2019 02:14:33", ChronoUnit.MINUTES, 1, "America/New_York");
+    }
+
+    @Test
+    public void quotaReset_1hour() throws ParseException {
+        testQuotaReset("08/03/2019 02:00:00", "08/03/2019 01:14:33", ChronoUnit.HOURS, 1, "America/New_York");
+    }
+
+    @Test
+    public void quotaReset_3hours() throws ParseException {
+        testQuotaReset("08/03/2019 02:00:00", "08/02/2019 23:44:21", ChronoUnit.HOURS, 3, "America/New_York");
+    }
+
+    @Test
+    public void quotaReset_1day() throws ParseException {
+        testQuotaReset("08/03/2019 04:00:00", "08/02/2019 04:01:54", ChronoUnit.DAYS, 1, "America/New_York");
+    }
+
+    @Test
+    public void quotaReset_1day_prev() throws ParseException {
+        testQuotaReset("08/02/2019 04:00:00", "08/02/2019 02:01:54", ChronoUnit.DAYS, 1, "America/New_York");
+    }
+
+    @Test
+    public void quotaReset_1day_utc() throws ParseException {
+        testQuotaReset("08/03/2019 00:00:00", "08/02/2019 04:01:54", ChronoUnit.DAYS, 1, "UTC");
+    }
+
+    @Test
+    public void quotaReset_1day_utc2() throws ParseException {
+        testQuotaReset("08/03/2019 00:00:00", "08/02/2019 04:01:54", ChronoUnit.DAYS, 1, "UTC");
+    }
+
+    @Test
+    public void quotaReset_1day_utc_next() throws ParseException {
+        testQuotaReset("08/03/2019 00:00:00", "08/02/2019 22:01:54", ChronoUnit.DAYS, 1, "UTC");
+    }
+
+    @Test
+    public void quotaReset_1day_cst() throws ParseException {
+        testQuotaReset("08/02/2019 05:00:00", "08/02/2019 04:01:54", ChronoUnit.DAYS, 1, "America/Chicago");
+    }
+
+    @Test
+    public void quotaReset_1week() throws ParseException {
+        testQuotaReset("08/08/2019 07:00:00", "08/02/2019 04:01:54", ChronoUnit.DAYS, 7, "PST");
+    }
+
+    @Test
+    public void quotaReset_1month() throws ParseException {
+        testQuotaReset("09/01/2019 07:00:00", "08/02/2019 04:01:54", ChronoUnit.MONTHS, 1, "PST");
+    }
+
+    private static final DateFormat DATE_CONVERTER = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss Z");
+    private static final String DATE_SUFFIX = " UTC";
+
+    private static void testQuotaReset(String expectedDate, String startDate, ChronoUnit unit, int increment, String timeZoneId)
+        throws ParseException {
+        long result = DateUtils.getEndOfPeriodForRound(parseDate(startDate, timeZoneId).getTime(), increment, unit, timeZoneId);
+        Assert.assertEquals(parseDate(expectedDate, timeZoneId), new Date(result));
+    }
+
+    private static Date parseDate(String dateUtc, String timeZoneId) throws ParseException {
+        return DATE_CONVERTER.parse(dateUtc + DATE_SUFFIX);
     }
 }

--- a/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/RateLimitPolicyTest.java
+++ b/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/RateLimitPolicyTest.java
@@ -17,7 +17,6 @@ package io.gravitee.policy.ratelimit;
 
 import static io.gravitee.common.http.GraviteeHttpHeader.X_GRAVITEE_API_KEY;
 import static io.gravitee.common.http.GraviteeHttpHeader.X_GRAVITEE_API_NAME;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.common.http.HttpHeaders;

--- a/pom.xml
+++ b/pom.xml
@@ -31,13 +31,13 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.3</version>
+        <version>21.0.0</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>2.7</gravitee-bom.version>
-        <gravitee-gateway-api.version>2.0.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.6.0</gravitee-policy-api.version>
+        <gravitee-bom.version>4.0.0</gravitee-bom.version>
+        <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-apim-repository-api.version>3.20.0-alpha.2-SNAPSHOT</gravitee-apim-repository-api.version>
         <gravitee-common.version>2.0.0</gravitee-common.version>
         <gravitee-node.version>2.0.1</gravitee-node.version>


### PR DESCRIPTION
…instead of strict increment

**Issue**

https://gravitee.atlassian.net/browse/APIM-1505

**Description**

Ad a new mode to the Quota Policy to define when the counter is ending:
* Strict end value based on the request timestamp
* * Round end value (still based on the request timestamp)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-apim-1505-period-start-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/2.1.0-apim-1505-period-start-SNAPSHOT/gravitee-ratelimit-parent-2.1.0-apim-1505-period-start-SNAPSHOT.zip)
  <!-- Version placeholder end -->
