### PR TITLE
chore(deps): update gravitee dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,25 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
+  "extends": ["config:base"],
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "ci"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "chore"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["major"],
+      "semanticCommitType": "chore"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -31,16 +31,16 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.3</version>
+        <version>21.0.1</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>2.7</gravitee-bom.version>
-        <gravitee-gateway-api.version>2.0.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.6.0</gravitee-policy-api.version>
-        <gravitee-apim-repository-api.version>3.20.0-alpha.2-SNAPSHOT</gravitee-apim-repository-api.version>
-        <gravitee-common.version>2.0.0</gravitee-common.version>
-        <gravitee-node.version>2.0.1</gravitee-node.version>
+        <gravitee-bom.version>3.0.24</gravitee-bom.version>
+        <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-apim-repository-api.version>3.20.29</gravitee-apim-repository-api.version>
+        <gravitee-common.version>2.3.0</gravitee-common.version>
+        <gravitee-node.version>2.1.0</gravitee-node.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
**Description**

Upgrade all Gravitee dependencies using the version defined in the latest 3.20.


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.2`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/2.0.2/gravitee-ratelimit-parent-2.0.2.zip)
  <!-- Version placeholder end -->
