### PR TITLE
fix: use async vertx lock mechanism

### DIFF
--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitRepository.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitRepository.java
@@ -18,169 +18,106 @@ package io.gravitee.gateway.services.ratelimit;
 import io.gravitee.repository.ratelimit.api.RateLimitRepository;
 import io.gravitee.repository.ratelimit.model.RateLimit;
 import io.reactivex.rxjava3.core.Completable;
-import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.core.SingleSource;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.functions.BiFunction;
-import io.reactivex.rxjava3.functions.Function;
-import java.util.Map;
+import io.vertx.rxjava3.core.Vertx;
+import io.vertx.rxjava3.core.shareddata.SharedData;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Setter
+@Slf4j
 public class AsyncRateLimitRepository implements RateLimitRepository<RateLimit> {
 
-    private final Logger logger = LoggerFactory.getLogger(AsyncRateLimitRepository.class);
-
+    private final Set<String> keys = new CopyOnWriteArraySet<>();
+    private final SharedData sharedData;
     private LocalRateLimitRepository localCacheRateLimitRepository;
     private RateLimitRepository<RateLimit> remoteCacheRateLimitRepository;
+    private Disposable mergeSubscription;
 
-    private final Set<String> keys = new CopyOnWriteArraySet<>();
-
-    private final BaseSchedulerProvider schedulerProvider;
-
-    // Get a map of lock for each rate-limit key to ensure data consistency during merge
-    private final Map<String, Semaphore> locks = new ConcurrentHashMap<>();
-
-    public AsyncRateLimitRepository(BaseSchedulerProvider schedulerProvider) {
-        this.schedulerProvider = schedulerProvider;
+    public AsyncRateLimitRepository(final Vertx vertx) {
+        this.sharedData = vertx.sharedData();
     }
 
     public void initialize() {
-        Disposable subscribe = Observable.timer(5000, TimeUnit.MILLISECONDS).repeat().subscribe(tick -> merge());
-        //TODO: dispose subscribe when service is stopped
+        mergeSubscription =
+            Flowable
+                .<Long, Long>generate(
+                    () -> 0L,
+                    (state, emitter) -> {
+                        emitter.onNext(state);
+                        return state + 1;
+                    }
+                )
+                .delay(5000, TimeUnit.MILLISECONDS)
+                .rebatchRequests(1)
+                .filter(interval -> !keys.isEmpty())
+                .flatMapCompletable(interval ->
+                    Flowable
+                        .fromIterable(keys)
+                        .flatMapCompletable(key ->
+                            sharedData
+                                .getLocalLock(key)
+                                .flatMapCompletable(lock ->
+                                    localCacheRateLimitRepository
+                                        .get(key)
+                                        // Remote rate is incremented by the local counter value
+                                        // If the remote does not contain existing value, use the local counter
+                                        .flatMapSingle(localRateLimit ->
+                                            remoteCacheRateLimitRepository
+                                                .incrementAndGet(key, localRateLimit.getLocal(), () -> localRateLimit)
+                                                .map(rateLimit -> {
+                                                    // Set the counter with the latest value from the repository
+                                                    localRateLimit.setCounter(rateLimit.getCounter());
+
+                                                    // Re-init the local counter
+                                                    localRateLimit.setLocal(0L);
+
+                                                    return localRateLimit;
+                                                })
+                                        )
+                                        // And save the new counter value into the local cache
+                                        .flatMapSingle(rateLimit -> localCacheRateLimitRepository.save(rateLimit))
+                                        .doOnSuccess(localRateLimit -> keys.remove(key))
+                                        .doOnError(throwable ->
+                                            log.error("An unexpected error occurs while refreshing asynchronous rate-limit", throwable)
+                                        )
+                                        .ignoreElement()
+                                        .doFinally(lock::release)
+                                )
+                        )
+                )
+                .onErrorComplete()
+                .subscribe();
+    }
+
+    public void clean() {
+        if (mergeSubscription != null) {
+            mergeSubscription.dispose();
+        }
     }
 
     @Override
     public Single<RateLimit> incrementAndGet(String key, long weight, Supplier<RateLimit> supplier) {
-        return isLocked(key)
-            .subscribeOn(schedulerProvider.computation())
-            .andThen(
-                Single.defer(() ->
-                    localCacheRateLimitRepository
-                        .incrementAndGet(key, weight, () -> new LocalRateLimit(supplier.get()))
-                        .map(localRateLimit -> {
-                            keys.add(localRateLimit.getKey());
-                            return localRateLimit;
-                        })
-                )
+        return sharedData
+            .getLocalLock(key)
+            .flatMap(lock ->
+                Single
+                    .defer(() ->
+                        localCacheRateLimitRepository
+                            .incrementAndGet(key, weight, () -> new LocalRateLimit(supplier.get()))
+                            .doOnSuccess(localRateLimit -> keys.add(localRateLimit.getKey()))
+                    )
+                    .doFinally(lock::release)
             );
-    }
-
-    void merge() {
-        if (!keys.isEmpty()) {
-            keys.forEach(
-                new java.util.function.Consumer<String>() {
-                    @Override
-                    public void accept(String key) {
-                        lock(key)
-                            // By default, delay signal are done through the computation scheduler
-                            //        .observeOn(Schedulers.computation())
-                            .andThen(
-                                localCacheRateLimitRepository
-                                    .get(key)
-                                    // Remote rate is incremented by the local counter value
-                                    // If the remote does not contains existing value, use the local counter
-                                    .flatMapSingle(
-                                        (Function<LocalRateLimit, SingleSource<RateLimit>>) localRateLimit ->
-                                            remoteCacheRateLimitRepository.incrementAndGet(
-                                                key,
-                                                localRateLimit.getLocal(),
-                                                () -> localRateLimit
-                                            )
-                                    )
-                                    .zipWith(
-                                        localCacheRateLimitRepository.get(key),
-                                        new BiFunction<RateLimit, LocalRateLimit, LocalRateLimit>() {
-                                            @Override
-                                            public LocalRateLimit apply(RateLimit rateLimit, LocalRateLimit localRateLimit)
-                                                throws Exception {
-                                                // Set the counter with the latest value from the repository
-                                                localRateLimit.setCounter(rateLimit.getCounter());
-
-                                                // Re-init the local counter
-                                                localRateLimit.setLocal(0L);
-
-                                                return localRateLimit;
-                                            }
-                                        }
-                                    )
-                                    // And save the new counter value into the local cache
-                                    .flatMapSingle(
-                                        (Function<LocalRateLimit, SingleSource<LocalRateLimit>>) rateLimit ->
-                                            localCacheRateLimitRepository.save(rateLimit)
-                                    )
-                                    .doAfterTerminate(() -> unlock(key))
-                                    .doOnError(throwable ->
-                                        logger.error("An unexpected error occurs while refreshing asynchronous rate-limit", throwable)
-                                    )
-                            )
-                            .subscribe();
-                    }
-                }
-            );
-
-            // Clear keys
-            keys.clear();
-        }
-    }
-
-    private Completable isLocked(String key) {
-        return Completable.create(emitter -> {
-            Semaphore sem = locks.get(key);
-
-            if (sem == null) {
-                emitter.onComplete();
-            } else {
-                // Wait until unlocked
-                boolean acquired = false;
-                while (!acquired) {
-                    acquired = sem.tryAcquire();
-                }
-
-                // Once we get access, release
-                sem.release();
-            }
-
-            emitter.onComplete();
-        });
-    }
-
-    private Completable lock(String key) {
-        return Completable.create(emitter -> {
-            Semaphore sem = locks.computeIfAbsent(key, key1 -> new Semaphore(1));
-
-            boolean acquired = false;
-            while (!acquired) {
-                acquired = sem.tryAcquire();
-            }
-
-            emitter.onComplete();
-        });
-    }
-
-    private void unlock(String key) {
-        Semaphore lock = this.locks.get(key);
-        if (lock != null) {
-            lock.release();
-        }
-    }
-
-    public void setLocalCacheRateLimitRepository(LocalRateLimitRepository localCacheRateLimitRepository) {
-        this.localCacheRateLimitRepository = localCacheRateLimitRepository;
-    }
-
-    public void setRemoteCacheRateLimitRepository(RateLimitRepository<RateLimit> remoteCacheRateLimitRepository) {
-        this.remoteCacheRateLimitRepository = remoteCacheRateLimitRepository;
     }
 }

--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/DefaultRateLimitService.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/DefaultRateLimitService.java
@@ -20,11 +20,15 @@ import io.gravitee.repository.ratelimit.api.RateLimitService;
 import io.gravitee.repository.ratelimit.model.RateLimit;
 import io.reactivex.rxjava3.core.Single;
 import java.util.function.Supplier;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
 public class DefaultRateLimitService implements RateLimitService {
 
     private RateLimitRepository<RateLimit> rateLimitRepository;
@@ -32,22 +36,6 @@ public class DefaultRateLimitService implements RateLimitService {
 
     private RateLimitRepository<RateLimit> getRateLimitRepository(boolean async) {
         return (async) ? asyncRateLimitRepository : rateLimitRepository;
-    }
-
-    public RateLimitRepository<RateLimit> getAsyncRateLimitRepository() {
-        return asyncRateLimitRepository;
-    }
-
-    public void setAsyncRateLimitRepository(RateLimitRepository<RateLimit> asyncRateLimitRepository) {
-        this.asyncRateLimitRepository = asyncRateLimitRepository;
-    }
-
-    public RateLimitRepository getRateLimitRepository() {
-        return rateLimitRepository;
-    }
-
-    public void setRateLimitRepository(RateLimitRepository<RateLimit> rateLimitRepository) {
-        this.rateLimitRepository = rateLimitRepository;
     }
 
     @Override

--- a/gravitee-gateway-services-ratelimit/src/test/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitRepositoryTest.java
+++ b/gravitee-gateway-services-ratelimit/src/test/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitRepositoryTest.java
@@ -17,10 +17,13 @@ package io.gravitee.gateway.services.ratelimit;
 
 import static org.mockito.Mockito.spy;
 
+import io.gravitee.gateway.services.ratelimit.rx.SchedulerProvider;
+import io.gravitee.gateway.services.ratelimit.rx.TestSchedulerProvider;
 import io.gravitee.gateway.services.ratelimit.rx.TrampolineSchedulerProvider;
 import io.gravitee.repository.ratelimit.api.RateLimitRepository;
 import io.gravitee.repository.ratelimit.model.RateLimit;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
+import io.vertx.rxjava3.core.Vertx;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -45,9 +48,9 @@ public class AsyncRateLimitRepositoryTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        localRateLimitRepository = spy(new LocalRateLimitRepository());
         testScheduler = new TestScheduler();
-        rateLimitRepository = spy(new AsyncRateLimitRepository(new TrampolineSchedulerProvider()));
+        localRateLimitRepository = spy(new LocalRateLimitRepository(new TestSchedulerProvider(testScheduler)));
+        rateLimitRepository = spy(new AsyncRateLimitRepository(Vertx.vertx()));
         rateLimitRepository.setLocalCacheRateLimitRepository(localRateLimitRepository);
         rateLimitRepository.setRemoteCacheRateLimitRepository(remoteRateLimitRepository);
     }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4815

**Description**

The async rate limiting repository was using locks in a way which could lead to blocking thread exception. The idea here is to simplify the code and remove the usage of semaphore and replace them by vertx local locks.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.1-APIM-4815-refactor-locks-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/2.1.1-APIM-4815-refactor-locks-SNAPSHOT/gravitee-ratelimit-parent-2.1.1-APIM-4815-refactor-locks-SNAPSHOT.zip)
  <!-- Version placeholder end -->
