### PR TITLE
feat: add new options to control behaviour in case of redis error

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -103,6 +103,24 @@ This policy does not prevent request spikes.
 |===
 |Property |Required |Description |Type |Default
 
+|Failover passthrough
+|No
+|In case of failure, the request is forwarded without rate limiting.
+|Boolean
+|false
+
+|Non-strict mode (async)
+|No
+|By activating this option, rate-limiting is applied in an asynchronous way meaning that the distributed counter value is not strict.
+|Boolean
+|false
+
+|Add response headers
+|No
+|Add X-Rate-Limit-Limit, X-Rate-Limit-Remaining and X-Rate-Limit-Reset headers in HTTP response.
+|Boolean
+|false
+
 |key
 |No
 |Key to identify a consumer to apply rate-limiting against. Leave it empty to use the default behavior (plan/subscription pair). Supports Expression Language.

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -1,0 +1,51 @@
+#
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: "3"
+
+env:
+    APIM_GW_DISTRIBUTION_PATH: "{{.APIM_GW_DISTRIBUTION_PATH }}"
+    APIM_MAPI_DISTRIBUTION_PATH: "{{.APIM_MAPI_DISTRIBUTION_PATH }}"
+
+tasks:
+    build:
+        desc: "Build"
+        cmds:
+            - mvn clean install -DskipTests -Dskip.validation
+
+    copy:
+        desc: "Copy policy"
+        cmds:
+            - find . -name 'gravitee-*.zip' -exec cp -v \{\} ${APIM_GW_DISTRIBUTION_PATH}/plugins \;
+            - find . -name 'gravitee-*.zip' -exec cp -v \{\} ${APIM_MAPI_DISTRIBUTION_PATH}/plugins \;
+
+    clean:
+        desc: "Clean"
+        cmds:
+            - rm -f ${APIM_GW_DISTRIBUTION_PATH}/plugins/gravitee-{policy-quota,policy-ratelimit,policy-spikearrest,gateway-services-ratelimit}-*.zip ${APIM_MAPI_DISTRIBUTION_PATH}/plugins/gravitee-{policy-quota,policy-ratelimit,policy-spikearrest,gateway-services-ratelimit}-*.zip
+
+    lint:
+        desc: "Lint"
+        cmds:
+            - mvn prettier:write
+
+    all:
+        desc: "Clean, Build and copy"
+        cmds:
+            - task: clean
+            - task: lint
+            - task: build
+            - task: copy

--- a/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfiguration.java
+++ b/gravitee-policy-quota/src/main/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfiguration.java
@@ -16,6 +16,7 @@
 package io.gravitee.policy.quota.configuration;
 
 import io.gravitee.policy.api.PolicyConfiguration;
+import io.gravitee.ratelimit.ErrorStrategy;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -30,6 +31,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class QuotaPolicyConfiguration implements PolicyConfiguration {
+
+    // for backward compatibility, we set the previous default behavior
+    @Builder.Default
+    private ErrorStrategy errorStrategy = ErrorStrategy.FALLBACK_PASS_TROUGH;
 
     private boolean async;
 

--- a/gravitee-policy-quota/src/main/java/io/gravitee/policy/v3/quota/QuotaPolicyV3.java
+++ b/gravitee-policy-quota/src/main/java/io/gravitee/policy/v3/quota/QuotaPolicyV3.java
@@ -59,6 +59,7 @@ public class QuotaPolicyV3 {
     protected static final String QUOTA_TOO_MANY_REQUESTS = "QUOTA_TOO_MANY_REQUESTS";
     protected static final String QUOTA_SERVER_ERROR = "QUOTA_SERVER_ERROR";
     protected static final String QUOTA_NOT_APPLIED = "QUOTA_NOT_APPLIED";
+    protected static final String QUOTA_BLOCK_ON_INTERNAL_ERROR = "QUOTA_BLOCK_ON_INTERNAL_ERROR";
 
     /**
      * The maximum number of requests that the consumer is permitted to make per time unit.

--- a/gravitee-policy-quota/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-quota/src/main/resources/schemas/schema-form.json
@@ -2,6 +2,19 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
+        "errorStrategy": {
+            "type": "string",
+            "title": "Error strategy",
+            "description": "Strategy applied to handle rate-limiting internal errors.",
+            "default": "FALLBACK_PASS_TROUGH",
+            "enum": ["BLOCK_ON_INTERNAL_ERROR", "FALLBACK_PASS_TROUGH"],
+            "gioConfig": {
+                "enumLabelMap": {
+                    "BLOCK_ON_INTERNAL_ERROR": "Block queries in case of internal failure",
+                    "FALLBACK_PASS_TROUGH": "Accept queries in case of internal failure (previous default behavior)"
+                }
+            }
+        },
         "async": {
             "type": "boolean",
             "default": false,

--- a/gravitee-policy-quota/src/test/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfigurationTest.java
+++ b/gravitee-policy-quota/src/test/java/io/gravitee/policy/quota/configuration/QuotaPolicyConfigurationTest.java
@@ -18,6 +18,7 @@ package io.gravitee.policy.quota.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.ratelimit.ErrorStrategy;
 import java.io.IOException;
 import java.net.URL;
 import java.time.temporal.ChronoUnit;
@@ -56,6 +57,23 @@ class QuotaPolicyConfigurationTest {
 
         assertThat(configuration).isEqualTo(
             QuotaPolicyConfiguration.builder()
+                .addHeaders(false)
+                .async(true)
+                .quota(QuotaConfiguration.builder().limit(10).periodTime(10).periodTimeUnit(ChronoUnit.MINUTES).build())
+                .build()
+        );
+    }
+
+    @Test
+    void test_quota03() throws IOException {
+        QuotaPolicyConfiguration configuration = load(
+            "/io/gravitee/policy/quota/configuration/quota03.json",
+            QuotaPolicyConfiguration.class
+        );
+
+        assertThat(configuration).isEqualTo(
+            QuotaPolicyConfiguration.builder()
+                .errorStrategy(ErrorStrategy.BLOCK_ON_INTERNAL_ERROR)
                 .addHeaders(false)
                 .async(true)
                 .quota(QuotaConfiguration.builder().limit(10).periodTime(10).periodTimeUnit(ChronoUnit.MINUTES).build())

--- a/gravitee-policy-quota/src/test/java/io/gravitee/policy/v3/quota/QuotaPolicyV3Test.java
+++ b/gravitee-policy-quota/src/test/java/io/gravitee/policy/v3/quota/QuotaPolicyV3Test.java
@@ -46,10 +46,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -60,6 +57,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @ExtendWith({ MockitoExtension.class })
 class QuotaPolicyV3Test {
 

--- a/gravitee-policy-quota/src/test/resources/io/gravitee/policy/quota/configuration/quota03.json
+++ b/gravitee-policy-quota/src/test/resources/io/gravitee/policy/quota/configuration/quota03.json
@@ -1,0 +1,10 @@
+{
+    "errorStrategy": "BLOCK_ON_INTERNAL_ERROR",
+    "addHeaders": false,
+    "async": true,
+    "quota": {
+        "limit": 10,
+        "periodTime": 10,
+        "periodTimeUnit": "MINUTES"
+    }
+}

--- a/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfiguration.java
+++ b/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfiguration.java
@@ -16,6 +16,7 @@
 package io.gravitee.policy.ratelimit.configuration;
 
 import io.gravitee.policy.api.PolicyConfiguration;
+import io.gravitee.ratelimit.ErrorStrategy;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -30,6 +31,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RateLimitPolicyConfiguration implements PolicyConfiguration {
+
+    // for backward compatibility, we set the previous default behavior
+    @Builder.Default
+    private ErrorStrategy errorStrategy = ErrorStrategy.FALLBACK_PASS_TROUGH;
 
     private boolean async;
 

--- a/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/v3/ratelimit/RateLimitPolicyV3.java
+++ b/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/v3/ratelimit/RateLimitPolicyV3.java
@@ -60,6 +60,7 @@ public class RateLimitPolicyV3 {
     protected static final String RATE_LIMIT_TOO_MANY_REQUESTS = "RATE_LIMIT_TOO_MANY_REQUESTS";
     protected static final String RATE_LIMIT_SERVER_ERROR = "RATE_LIMIT_SERVER_ERROR";
     protected static final String RATE_LIMIT_NOT_APPLIED = "RATE_LIMIT_NOT_APPLIED";
+    protected static final String RATE_LIMIT_BLOCK_ON_INTERNAL_ERROR = "RATE_LIMIT_BLOCK_ON_INTERNAL_ERROR";
 
     /**
      * The maximum number of requests that the consumer is permitted to make per time unit.

--- a/gravitee-policy-ratelimit/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-ratelimit/src/main/resources/schemas/schema-form.json
@@ -2,6 +2,19 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
+        "errorStrategy": {
+            "type": "string",
+            "title": "Error strategy",
+            "description": "Strategy applied to handle rate-limiting internal errors.",
+            "default": "FALLBACK_PASS_TROUGH",
+            "enum": ["BLOCK_ON_INTERNAL_ERROR", "FALLBACK_PASS_TROUGH"],
+            "gioConfig": {
+                "enumLabelMap": {
+                    "BLOCK_ON_INTERNAL_ERROR": "Block queries in case of internal failure",
+                    "FALLBACK_PASS_TROUGH": "Accept queries in case of internal failure (default behavior)"
+                }
+            }
+        },
         "async": {
             "type": "boolean",
             "default": false,
@@ -62,5 +75,5 @@
             "required": ["periodTime", "periodTimeUnit"]
         }
     },
-    "required": ["rate"]
+    "required": ["rate", "errorStrategy"]
 }

--- a/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfigurationTest.java
+++ b/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/ratelimit/configuration/RateLimitPolicyConfigurationTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.policy.ratelimit.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.ratelimit.ErrorStrategy;
 import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
@@ -37,6 +38,7 @@ public class RateLimitPolicyConfigurationTest {
 
         Assertions.assertThat(configuration).isEqualTo(
             RateLimitPolicyConfiguration.builder()
+                .errorStrategy(ErrorStrategy.FALLBACK_PASS_TROUGH)
                 .rate(
                     RateLimitConfiguration.builder()
                         .limit(10)
@@ -58,9 +60,34 @@ public class RateLimitPolicyConfigurationTest {
 
         Assertions.assertThat(configuration).isEqualTo(
             RateLimitPolicyConfiguration.builder()
+                .errorStrategy(ErrorStrategy.FALLBACK_PASS_TROUGH)
                 .async(true)
                 .addHeaders(true)
                 .rate(RateLimitConfiguration.builder().limit(10).periodTime(10).periodTimeUnit(TimeUnit.MINUTES).build())
+                .build()
+        );
+    }
+
+    @Test
+    public void test_quota03() throws IOException {
+        RateLimitPolicyConfiguration configuration = load(
+            "/io/gravitee/policy/ratelimit/configuration/ratelimit03.json",
+            RateLimitPolicyConfiguration.class
+        );
+
+        Assertions.assertThat(configuration).isEqualTo(
+            RateLimitPolicyConfiguration.builder()
+                .errorStrategy(ErrorStrategy.BLOCK_ON_INTERNAL_ERROR)
+                .async(false)
+                .addHeaders(false)
+                .rate(
+                    RateLimitConfiguration.builder()
+                        .dynamicLimit("{(2*5)}")
+                        .limit(10)
+                        .periodTime(10)
+                        .periodTimeUnit(TimeUnit.MINUTES)
+                        .build()
+                )
                 .build()
         );
     }

--- a/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/v3/ratelimit/RateLimitPolicyV3Test.java
+++ b/gravitee-policy-ratelimit/src/test/java/io/gravitee/policy/v3/ratelimit/RateLimitPolicyV3Test.java
@@ -45,10 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -59,6 +56,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @ExtendWith(MockitoExtension.class)
 public class RateLimitPolicyV3Test {
 

--- a/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit03.json
+++ b/gravitee-policy-ratelimit/src/test/resources/io/gravitee/policy/ratelimit/configuration/ratelimit03.json
@@ -1,0 +1,9 @@
+{
+    "errorStrategy": "BLOCK_ON_INTERNAL_ERROR",
+    "rate": {
+        "limit": 10,
+        "dynamicLimit": "{(2*5)}",
+        "periodTime": 10,
+        "periodTimeUnit": "MINUTES"
+    }
+}

--- a/gravitee-policy-spikearrest/src/main/java/io/gravitee/policy/spike/configuration/SpikeArrestPolicyConfiguration.java
+++ b/gravitee-policy-spikearrest/src/main/java/io/gravitee/policy/spike/configuration/SpikeArrestPolicyConfiguration.java
@@ -16,6 +16,7 @@
 package io.gravitee.policy.spike.configuration;
 
 import io.gravitee.policy.api.PolicyConfiguration;
+import io.gravitee.ratelimit.ErrorStrategy;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -30,6 +31,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SpikeArrestPolicyConfiguration implements PolicyConfiguration {
+
+    // for backward compatibility, we set the previous default behavior
+    @Builder.Default
+    private ErrorStrategy errorStrategy = ErrorStrategy.FALLBACK_PASS_TROUGH;
 
     private boolean async;
 

--- a/gravitee-policy-spikearrest/src/main/java/io/gravitee/policy/v3/spike/SpikeArrestPolicyV3.java
+++ b/gravitee-policy-spikearrest/src/main/java/io/gravitee/policy/v3/spike/SpikeArrestPolicyV3.java
@@ -62,6 +62,7 @@ public class SpikeArrestPolicyV3 {
     protected static final String SPIKE_ARREST_TOO_MANY_REQUESTS = "SPIKE_ARREST_TOO_MANY_REQUESTS";
     protected static final String SPIKE_ARREST_SERVER_ERROR = "SPIKE_ARREST_SERVER_ERROR";
     protected static final String SPIKE_ARREST_NOT_APPLIED = "SPIKE_ARREST_NOT_APPLIED";
+    protected static final String SPIKE_ARREST_BLOCK_ON_INTERNAL_ERROR = "SPIKE_ARREST_BLOCK_ON_INTERNAL_ERROR";
 
     /**
      * The maximum number of requests that the backend is allowed to receive per time unit.

--- a/gravitee-policy-spikearrest/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-spikearrest/src/main/resources/schemas/schema-form.json
@@ -2,6 +2,19 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
+        "errorStrategy": {
+            "type": "string",
+            "title": "Error strategy",
+            "description": "Strategy applied to handle rate-limiting internal errors.",
+            "default": "FALLBACK_PASS_TROUGH",
+            "enum": ["BLOCK_ON_INTERNAL_ERROR", "FALLBACK_PASS_TROUGH"],
+            "gioConfig": {
+                "enumLabelMap": {
+                    "BLOCK_ON_INTERNAL_ERROR": "Block queries in case of internal failure",
+                    "FALLBACK_PASS_TROUGH": "Accept queries in case of internal failure (previous default behavior)"
+                }
+            }
+        },
         "async": {
             "type": "boolean",
             "default": false,

--- a/gravitee-policy-spikearrest/src/test/java/io/gravitee/policy/spike/configuration/SpikeArrestPolicyConfigurationTest.java
+++ b/gravitee-policy-spikearrest/src/test/java/io/gravitee/policy/spike/configuration/SpikeArrestPolicyConfigurationTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.policy.spike.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.ratelimit.ErrorStrategy;
 import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +53,25 @@ public class SpikeArrestPolicyConfigurationTest {
 
         org.assertj.core.api.Assertions.assertThat(configuration).isEqualTo(
             SpikeArrestPolicyConfiguration.builder()
+                .addHeaders(true)
+                .async(true)
+                .spike(
+                    SpikeArrestConfiguration.builder().limit(0).dynamicLimit("10").periodTime(10).periodTimeUnit(TimeUnit.MINUTES).build()
+                )
+                .build()
+        );
+    }
+
+    @Test
+    public void test_spikeArrest03() throws IOException {
+        SpikeArrestPolicyConfiguration configuration = load(
+            "/io/gravitee/policy/spike/configuration/spikearrest03.json",
+            SpikeArrestPolicyConfiguration.class
+        );
+
+        org.assertj.core.api.Assertions.assertThat(configuration).isEqualTo(
+            SpikeArrestPolicyConfiguration.builder()
+                .errorStrategy(ErrorStrategy.BLOCK_ON_INTERNAL_ERROR)
                 .addHeaders(true)
                 .async(true)
                 .spike(

--- a/gravitee-policy-spikearrest/src/test/java/io/gravitee/policy/v3/spike/SpikeArrestPolicyV3Test.java
+++ b/gravitee-policy-spikearrest/src/test/java/io/gravitee/policy/v3/spike/SpikeArrestPolicyV3Test.java
@@ -44,10 +44,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -58,6 +55,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @ExtendWith(MockitoExtension.class)
 public class SpikeArrestPolicyV3Test {
 

--- a/gravitee-policy-spikearrest/src/test/resources/io/gravitee/policy/spike/configuration/spikearrest03.json
+++ b/gravitee-policy-spikearrest/src/test/resources/io/gravitee/policy/spike/configuration/spikearrest03.json
@@ -1,0 +1,10 @@
+{
+    "errorStrategy": "BLOCK_ON_INTERNAL_ERROR",
+    "addHeaders": true,
+    "async": true,
+    "spike": {
+        "dynamicLimit": "10",
+        "periodTime": 10,
+        "periodTimeUnit": "MINUTES"
+    }
+}

--- a/gravitee-ratelimit-shared/src/main/java/io/gravitee/ratelimit/ErrorStrategy.java
+++ b/gravitee-ratelimit-shared/src/main/java/io/gravitee/ratelimit/ErrorStrategy.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ratelimit;
+
+public enum ErrorStrategy {
+    BLOCK_ON_INTERNAL_ERROR,
+    FALLBACK_PASS_TROUGH,
+}

--- a/gravitee-ratelimit-shared/src/main/java/io/gravitee/ratelimit/PolicyRateLimitException.java
+++ b/gravitee-ratelimit-shared/src/main/java/io/gravitee/ratelimit/PolicyRateLimitException.java
@@ -15,9 +15,7 @@
  */
 package io.gravitee.ratelimit;
 
-import io.gravitee.common.http.MediaType;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
-import io.vertx.core.json.JsonObject;
 import java.util.Map;
 import lombok.Getter;
 
@@ -38,6 +36,11 @@ public class PolicyRateLimitException extends Exception {
 
     public static PolicyRateLimitException overflow(String key, String message, Map<String, Object> parameters) {
         var ex = new ExecutionFailure(429).key(key).message(message).parameters(parameters);
+        return new PolicyRateLimitException(ex);
+    }
+
+    public static PolicyRateLimitException overflow(String key, String message, Throwable throwable) {
+        var ex = new ExecutionFailure(429).key(key).message(message).cause(throwable);
         return new PolicyRateLimitException(ex);
     }
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/PEN-35

**Description**


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-mba-pen-35-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/4.1.0-mba-pen-35-SNAPSHOT/gravitee-ratelimit-parent-4.1.0-mba-pen-35-SNAPSHOT.zip)
  <!-- Version placeholder end -->
