### PR TITLE
fix(ratelimit): reuse static Completable on success path

### DIFF
--- a/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/RateLimitPolicy.java
+++ b/gravitee-policy-ratelimit/src/main/java/io/gravitee/policy/ratelimit/RateLimitPolicy.java
@@ -44,6 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 public class RateLimitPolicy extends RateLimitPolicyV3 implements HttpPolicy {
 
     private static final KeyFactory KEY_FACTORY = new KeyFactory("rl");
+    private static final Completable COMPLETED = Completable.complete();
 
     public RateLimitPolicy(RateLimitPolicyConfiguration rateLimitPolicyConfiguration) {
         super(rateLimitPolicyConfiguration);
@@ -123,7 +124,7 @@ public class RateLimitPolicy extends RateLimitPolicyV3 implements HttpPolicy {
                     }
 
                     if (rateLimit.getCounter() <= limit) {
-                        return Completable.complete();
+                        return COMPLETED;
                     } else {
                         String message = String.format(
                             "Rate limit exceeded! You reached the limit of %d requests per %d %s",
@@ -173,7 +174,7 @@ public class RateLimitPolicy extends RateLimitPolicyV3 implements HttpPolicy {
                         .message("Request bypassed rate limit policy due to internal error")
                         .cause(throwable)
                 );
-                yield Completable.complete();
+                yield COMPLETED;
             }
         };
     }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14010

**Description**

Reuse static Completable on success path.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.3.1-fix-ratelimit-completed-completable-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/4.3.1-fix-ratelimit-completed-completable-SNAPSHOT/gravitee-ratelimit-parent-4.3.1-fix-ratelimit-completed-completable-SNAPSHOT.zip)
  <!-- Version placeholder end -->
