### PR TITLE
feat(ratelimit-service): async repository and service

### DIFF
--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitService.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitService.java
@@ -18,7 +18,10 @@ package io.gravitee.gateway.services.ratelimit;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.repository.ratelimit.api.RateLimitRepository;
 import io.gravitee.repository.ratelimit.api.RateLimitService;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitService;
 import io.gravitee.repository.ratelimit.model.RateLimit;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
 import io.vertx.rxjava3.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +45,7 @@ public class AsyncRateLimitService extends AbstractService {
     private Vertx vertx;
 
     private AsyncRateLimitRepository asyncRateLimitRepository;
+    private AsyncTokenBucketRateLimitRepository asyncTokenBucketRateLimitRepository;
 
     @Override
     protected void doStart() throws Exception {
@@ -80,6 +84,50 @@ public class AsyncRateLimitService extends AbstractService {
             rateLimitService.setAsyncRateLimitRepository(rateLimitRepository);
             parentBeanFactory.registerSingleton(RateLimitService.class.getName(), rateLimitService);
         }
+
+        registerTokenBucketService(beanFactory, parentBeanFactory);
+    }
+
+    /**
+     * Register the token-bucket service bridge, mirroring the rate-limit one. Guarded by the presence
+     * of a token-bucket repository so an older repository plugin (without token-bucket support) cannot
+     * break the rate-limit async service.
+     */
+    @SuppressWarnings("unchecked")
+    private void registerTokenBucketService(DefaultListableBeanFactory beanFactory, DefaultListableBeanFactory parentBeanFactory) {
+        if (parentBeanFactory.getBeanNamesForType(TokenBucketRateLimitRepository.class).length == 0) {
+            LOGGER.warn("No token-bucket rate-limit repository found; the token-bucket service is not registered");
+            return;
+        }
+
+        TokenBucketRateLimitRepository<TokenBucket> tokenBucketRepository = parentBeanFactory.getBean(TokenBucketRateLimitRepository.class);
+        LOGGER.debug("Token-bucket repository implementation is {}", tokenBucketRepository.getClass().getName());
+
+        DefaultTokenBucketRateLimitService tokenBucketService = new DefaultTokenBucketRateLimitService();
+        tokenBucketService.setTokenBucketRateLimitRepository(tokenBucketRepository);
+
+        if (enabled) {
+            LocalTokenBucketRateLimitRepository localCacheTokenBucketRepository = new LocalTokenBucketRateLimitRepository();
+
+            LOGGER.debug(
+                "Register token-bucket repository asynchronous implementation {}",
+                AsyncTokenBucketRateLimitRepository.class.getName()
+            );
+            asyncTokenBucketRateLimitRepository = new AsyncTokenBucketRateLimitRepository(vertx);
+            beanFactory.autowireBean(asyncTokenBucketRateLimitRepository);
+            asyncTokenBucketRateLimitRepository.setLocalCacheTokenBucketRepository(localCacheTokenBucketRepository);
+            asyncTokenBucketRateLimitRepository.setRemoteCacheTokenBucketRepository(tokenBucketRepository);
+            asyncTokenBucketRateLimitRepository.initialize();
+
+            LOGGER.info("Register the token-bucket service bridge for synchronous and asynchronous mode");
+            tokenBucketService.setAsyncTokenBucketRateLimitRepository(asyncTokenBucketRateLimitRepository);
+        } else {
+            // Async disabled: only strict token-bucket mode is allowed.
+            LOGGER.info("Register the token-bucket service bridge for strict mode only");
+            tokenBucketService.setAsyncTokenBucketRateLimitRepository(tokenBucketRepository);
+        }
+
+        parentBeanFactory.registerSingleton(TokenBucketRateLimitService.class.getName(), tokenBucketService);
     }
 
     @Override
@@ -87,6 +135,9 @@ public class AsyncRateLimitService extends AbstractService {
         super.doStop();
         if (enabled && asyncRateLimitRepository != null) {
             asyncRateLimitRepository.clean();
+        }
+        if (enabled && asyncTokenBucketRateLimitRepository != null) {
+            asyncTokenBucketRateLimitRepository.clean();
         }
     }
 

--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncTokenBucketRateLimitRepository.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncTokenBucketRateLimitRepository.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.ratelimit;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.vertx.rxjava3.core.Vertx;
+import io.vertx.rxjava3.core.shareddata.SharedData;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Non-strict token-bucket repository. Every request refills and consumes against a node-local bucket
+ * ({@link LocalTokenBucketRateLimitRepository}) with no store round-trip; a scheduler periodically
+ * reconciles each touched key's locally-consumed delta to the backing store. The token-bucket
+ * analogue of {@code AsyncRateLimitRepository}.
+ */
+@Setter
+@Slf4j
+public class AsyncTokenBucketRateLimitRepository implements TokenBucketRateLimitRepository<TokenBucket> {
+
+    private static final Long LOCK_TIMEOUT_MILLIS = 250L;
+
+    private final Set<String> keys = new CopyOnWriteArraySet<>();
+    private final SharedData sharedData;
+    private LocalTokenBucketRateLimitRepository localCacheTokenBucketRepository;
+    private TokenBucketRateLimitRepository<TokenBucket> remoteCacheTokenBucketRepository;
+    private Disposable mergeSubscription;
+
+    public AsyncTokenBucketRateLimitRepository(final Vertx vertx) {
+        this.sharedData = vertx.sharedData();
+    }
+
+    @Override
+    public Single<TokenBucketConsumeResult> refillAndTryConsume(
+        String key,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis,
+        Supplier<TokenBucket> supplier
+    ) {
+        return sharedData
+            .getLocalLockWithTimeout(key, LOCK_TIMEOUT_MILLIS)
+            .flatMap(lock ->
+                Single.defer(() ->
+                    localCacheTokenBucketRepository
+                        .refillAndTryConsume(key, tokensRequested, refillRate, refillPeriodMillis, capacity, nowMillis, () ->
+                            new LocalTokenBucket(supplier.get())
+                        )
+                        .doOnSuccess(result -> keys.add(key))
+                ).doFinally(lock::release)
+            );
+    }
+
+    public void initialize() {
+        mergeSubscription = Flowable.<Long, Long>generate(
+            () -> 0L,
+            (state, emitter) -> {
+                emitter.onNext(state);
+                return state + 1;
+            }
+        )
+            .delay(5000, TimeUnit.MILLISECONDS)
+            .rebatchRequests(1)
+            .filter(interval -> !keys.isEmpty())
+            .concatMapCompletable(interval ->
+                Flowable.fromIterable(keys).flatMapCompletable(key ->
+                    sharedData
+                        .getLocalLock(key)
+                        .flatMapCompletable(lock ->
+                            localCacheTokenBucketRepository
+                                .get(key)
+                                .flatMapSingle(this::reconcile)
+                                .doFinally(lock::release)
+                                .doOnSuccess(local -> keys.remove(key))
+                                // Outer level so a get(key) failure is logged too, not only a reconcile() error
+                                // (matches AsyncRateLimitRepository). The key is removed only on success, so a
+                                // transient store error leaves it tracked and is retried next cycle.
+                                .doOnError(throwable ->
+                                    log.error("Failed to reconcile asynchronous token-bucket for key '{}'", key, throwable)
+                                )
+                                .onErrorComplete()
+                                .ignoreElement()
+                        )
+                )
+            )
+            .onErrorComplete()
+            .subscribe();
+    }
+
+    /**
+     * Push the node's locally-consumed delta to the store as a single batched consume, then re-anchor the
+     * local bucket from the store's verdict. The local view stays approximate between reconciles (other
+     * nodes consume too), which is the non-strict trade-off.
+     *
+     * <p>The batched consume is all-or-nothing: if the store has fewer tokens than the delta it debits
+     * nothing and returns {@code allowed=false}. That outcome means the global bucket is depleted — the
+     * cluster has hit the limit — so this node is treated as out of tokens and throttles back to its local
+     * refill rate, rather than re-arming to the store's still-positive remaining and over-serving again.
+     * The over-served delta cannot be un-served; it is dropped (a bounded, one-time overshoot) rather than
+     * carried forward, which would balloon the debt under sustained overload.
+     */
+    private Single<LocalTokenBucket> reconcile(LocalTokenBucket local) {
+        long now = System.currentTimeMillis();
+        Single<TokenBucketConsumeResult> remoteCall = remoteCacheTokenBucketRepository.refillAndTryConsume(
+            local.getKey(),
+            local.getLocalConsumed(),
+            local.getRefillRate(),
+            local.getRefillPeriodMillis(),
+            local.getCapacity(),
+            now,
+            // Seed the store with a PLAIN TokenBucket, never the LocalTokenBucket subclass: a distributed
+            // store (e.g. Hazelcast) serialises the seed across the cluster, and the gateway-services class
+            // is not on the store plugin's classloader (ClassNotFoundException). The store only needs the
+            // key + subscription, which the copy carries.
+            () -> new TokenBucket(local)
+        );
+
+        // A null Single means rate limiting is disabled (no-op store): nothing to reconcile, just clear the delta.
+        if (remoteCall == null) {
+            local.setLocalConsumed(0L);
+            return localCacheTokenBucketRepository.save(local);
+        }
+
+        return remoteCall
+            .map(result -> {
+                // allowed: the store accepted the batch; adopt its authoritative remaining.
+                // rejected: the store is depleted; throttle this node (0 tokens) so it does not over-serve again.
+                local.setTokens(result.allowed() ? result.remainingTokens() : 0L);
+                local.setLastRefillTime(now);
+                local.setLocalConsumed(0L);
+                return local;
+            })
+            .flatMap(localCacheTokenBucketRepository::save);
+    }
+
+    public void clean() {
+        if (mergeSubscription != null) {
+            mergeSubscription.dispose();
+        }
+    }
+}

--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/DefaultTokenBucketRateLimitService.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/DefaultTokenBucketRateLimitService.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.ratelimit;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitService;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.reactivex.rxjava3.core.Single;
+import java.util.function.Supplier;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Bridge that selects the strict (per-request, exact) or async (local-then-reconcile, non-strict)
+ * token-bucket repository based on the {@code async} flag. The token-bucket analogue of
+ * {@code DefaultRateLimitService}.
+ */
+@Getter
+@Setter
+public class DefaultTokenBucketRateLimitService implements TokenBucketRateLimitService {
+
+    private TokenBucketRateLimitRepository<TokenBucket> tokenBucketRateLimitRepository;
+    private TokenBucketRateLimitRepository<TokenBucket> asyncTokenBucketRateLimitRepository;
+
+    private TokenBucketRateLimitRepository<TokenBucket> repository(boolean async) {
+        return async ? asyncTokenBucketRateLimitRepository : tokenBucketRateLimitRepository;
+    }
+
+    @Override
+    public Single<TokenBucketConsumeResult> refillAndTryConsume(
+        String key,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis,
+        boolean async,
+        Supplier<TokenBucket> supplier
+    ) {
+        try {
+            return repository(async).refillAndTryConsume(
+                key,
+                tokensRequested,
+                refillRate,
+                refillPeriodMillis,
+                capacity,
+                nowMillis,
+                supplier
+            );
+        } catch (Exception ex) {
+            return Single.error(ex);
+        }
+    }
+}

--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/LocalTokenBucket.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/LocalTokenBucket.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.ratelimit;
+
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+
+/**
+ * A node-local token bucket. It is an ordinary {@link TokenBucket} (so the shared
+ * {@code TokenBucketCalculator} can refill and consume it like any other) plus {@code localConsumed}:
+ * the number of tokens consumed on this node since the last reconcile, waiting to be pushed to the
+ * store. Mirrors {@code LocalRateLimit}, where {@code local} is the pending delta.
+ *
+ * <p>Because it {@code is-a} {@link TokenBucket}, an instance must never be handed to the backing store
+ * (a distributed store serialises it, and this gateway-services class is absent from the store plugin's
+ * classloader). The single place that could leak it — the reconcile seed — copies into a plain
+ * {@link TokenBucket} on purpose; see {@code AsyncTokenBucketRateLimitRepository#reconcile}.
+ */
+class LocalTokenBucket extends TokenBucket {
+
+    private long localConsumed;
+
+    // The bucket parameters from the most recent request, replayed to the store at reconcile time
+    // (refill/consume needs them, but they are not part of the persisted TokenBucket model).
+    private long refillRate;
+    private long refillPeriodMillis;
+    private long capacity;
+
+    LocalTokenBucket(TokenBucket seed) {
+        super(seed);
+    }
+
+    long getLocalConsumed() {
+        return localConsumed;
+    }
+
+    void setLocalConsumed(long localConsumed) {
+        this.localConsumed = localConsumed;
+    }
+
+    void addLocalConsumed(long delta) {
+        this.localConsumed += delta;
+    }
+
+    long getRefillRate() {
+        return refillRate;
+    }
+
+    long getRefillPeriodMillis() {
+        return refillPeriodMillis;
+    }
+
+    long getCapacity() {
+        return capacity;
+    }
+
+    void rememberConfig(long refillRate, long refillPeriodMillis, long capacity) {
+        this.refillRate = refillRate;
+        this.refillPeriodMillis = refillPeriodMillis;
+        this.capacity = capacity;
+    }
+}

--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/LocalTokenBucketRateLimitRepository.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/LocalTokenBucketRateLimitRepository.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.ratelimit;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketCalculator;
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * In-memory, per-node token-bucket store backing the async path. It refills and consumes against a
+ * local copy of the bucket using the same {@link TokenBucketCalculator} as the strict backends, with
+ * no store round-trip, and tracks the locally-consumed delta so the async repository can reconcile it
+ * to the real store later. The async analogue of {@code LocalRateLimitRepository}.
+ */
+public class LocalTokenBucketRateLimitRepository implements TokenBucketRateLimitRepository<LocalTokenBucket> {
+
+    private final ConcurrentMap<String, LocalTokenBucket> buckets = new ConcurrentHashMap<>();
+
+    public LocalTokenBucketRateLimitRepository() {}
+
+    @Override
+    public Single<TokenBucketConsumeResult> refillAndTryConsume(
+        String key,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis,
+        Supplier<LocalTokenBucket> supplier
+    ) {
+        return Single.fromCallable(() -> {
+            AtomicReference<TokenBucketConsumeResult> resultRef = new AtomicReference<>();
+            buckets.compute(key, (k, bucket) -> {
+                // First touch on this node: seed a full bucket, just like the strict backends.
+                if (bucket == null) {
+                    bucket = supplier.get();
+                    TokenBucketCalculator.newFullBucket(bucket, capacity, nowMillis);
+                }
+                TokenBucketConsumeResult result = TokenBucketCalculator.refillAndTryConsume(
+                    bucket,
+                    tokensRequested,
+                    refillRate,
+                    refillPeriodMillis,
+                    capacity,
+                    nowMillis
+                );
+                // Only consumed tokens count toward the delta we owe the store.
+                if (result.allowed()) {
+                    bucket.addLocalConsumed(tokensRequested);
+                }
+                // Remember the parameters so the reconcile can replay them to the store.
+                bucket.rememberConfig(refillRate, refillPeriodMillis, capacity);
+                resultRef.set(result);
+                return bucket;
+            });
+            return resultRef.get();
+        }).subscribeOn(Schedulers.computation());
+    }
+
+    Maybe<LocalTokenBucket> get(String key) {
+        return Maybe.fromCallable(() -> buckets.get(key)).subscribeOn(Schedulers.computation());
+    }
+
+    Single<LocalTokenBucket> save(LocalTokenBucket bucket) {
+        return Single.fromCallable(() -> {
+            buckets.put(bucket.getKey(), bucket);
+            return bucket;
+        }).subscribeOn(Schedulers.computation());
+    }
+}

--- a/gravitee-gateway-services-ratelimit/src/test/java/io/gravitee/gateway/services/ratelimit/AsyncTokenBucketRateLimitRepositoryTest.java
+++ b/gravitee-gateway-services-ratelimit/src/test/java/io/gravitee/gateway/services/ratelimit/AsyncTokenBucketRateLimitRepositoryTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.rxjava3.core.Vertx;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class AsyncTokenBucketRateLimitRepositoryTest {
+
+    private LocalTokenBucketRateLimitRepository localCache;
+
+    @Mock
+    private TokenBucketRateLimitRepository<TokenBucket> remoteCache;
+
+    private final Vertx vertx = Vertx.vertx();
+
+    private AsyncTokenBucketRateLimitRepository cut;
+
+    private final String key = "key1";
+
+    @BeforeEach
+    void setUp() {
+        localCache = new LocalTokenBucketRateLimitRepository();
+        cut = new AsyncTokenBucketRateLimitRepository(vertx);
+        cut.setLocalCacheTokenBucketRepository(localCache);
+        cut.setRemoteCacheTokenBucketRepository(remoteCache);
+    }
+
+    @AfterEach
+    void tearDown() {
+        cut.clean();
+    }
+
+    @Test
+    void consumes_locally_without_calling_the_remote_store() {
+        TokenBucketConsumeResult result = cut.refillAndTryConsume(key, 1, 1, 1_000L, 5, 1_000L, () -> new TokenBucket(key)).blockingGet();
+
+        assertThat(result.allowed()).isTrue();
+        assertThat(result.remainingTokens()).isEqualTo(4); // served from the local bucket
+        verify(remoteCache, never()).refillAndTryConsume(anyString(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any());
+    }
+
+    @Test
+    void reconciles_the_local_delta_to_the_remote_store_and_adopts_its_remaining() throws InterruptedException {
+        // After consuming the pushed delta, the store authoritatively reports 7 tokens remaining.
+        when(remoteCache.refillAndTryConsume(eq(key), eq(2L), anyLong(), anyLong(), anyLong(), anyLong(), any())).thenReturn(
+            Single.just(new TokenBucketConsumeResult(true, 7, 0))
+        );
+
+        cut.initialize();
+
+        // Two local consumes (capacity 10, same instant so no refill): local delta = 2, store untouched.
+        cut.refillAndTryConsume(key, 1, 1, 1_000L, 10, 1_000L, () -> new TokenBucket(key)).blockingGet();
+        cut.refillAndTryConsume(key, 1, 1, 1_000L, 10, 1_000L, () -> new TokenBucket(key)).blockingGet();
+        verify(remoteCache, never()).refillAndTryConsume(anyString(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any());
+
+        Thread.sleep(6_000); // wait for the ~5s reconcile scheduler to fire
+
+        // The batched delta of 2 is pushed to the store exactly once.
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Supplier<TokenBucket>> seedCaptor = ArgumentCaptor.forClass(Supplier.class);
+        verify(remoteCache).refillAndTryConsume(eq(key), eq(2L), anyLong(), anyLong(), anyLong(), anyLong(), seedCaptor.capture());
+
+        // The store seed must be a PLAIN TokenBucket, never the LocalTokenBucket subclass: a distributed
+        // store serialises it across the cluster where the gateway-services class is not on the classpath.
+        assertThat(seedCaptor.getValue().get().getClass()).isEqualTo(TokenBucket.class);
+
+        LocalTokenBucket local = localCache.get(key).blockingGet();
+        assertThat(local.getTokens()).isEqualTo(7); // local bucket adopts the store's authoritative remaining
+        assertThat(local.getLocalConsumed()).isEqualTo(0); // delta cleared after a successful sync
+    }
+
+    @Test
+    void throttles_the_node_to_zero_when_the_store_rejects_the_reconciled_batch() throws InterruptedException {
+        // Store is depleted: it cannot satisfy the batched delta, so it debits nothing and returns
+        // allowed=false with a small positive remaining. The node must NOT re-arm to that remaining
+        // (which would keep over-serving), it must throttle to its local refill rate.
+        when(remoteCache.refillAndTryConsume(eq(key), eq(2L), anyLong(), anyLong(), anyLong(), anyLong(), any())).thenReturn(
+            Single.just(new TokenBucketConsumeResult(false, 3, 0))
+        );
+
+        cut.initialize();
+
+        cut.refillAndTryConsume(key, 1, 1, 1_000L, 10, 1_000L, () -> new TokenBucket(key)).blockingGet();
+        cut.refillAndTryConsume(key, 1, 1, 1_000L, 10, 1_000L, () -> new TokenBucket(key)).blockingGet();
+
+        Thread.sleep(6_000); // wait for the ~5s reconcile scheduler to fire
+
+        verify(remoteCache).refillAndTryConsume(eq(key), eq(2L), anyLong(), anyLong(), anyLong(), anyLong(), any());
+
+        LocalTokenBucket local = localCache.get(key).blockingGet();
+        assertThat(local.getTokens()).isEqualTo(0); // throttled on rejection, NOT re-armed to the store's remaining (3)
+        assertThat(local.getLocalConsumed()).isEqualTo(0); // un-absorbable delta dropped, not carried forward
+    }
+
+    @Test
+    void clears_the_local_delta_without_error_when_the_store_is_a_no_op() throws InterruptedException {
+        // A null Single is the documented no-op contract: rate limiting disabled. Reconcile must just clear
+        // the locally-consumed delta and re-save the bucket, never accumulate it or emit an error.
+        when(remoteCache.refillAndTryConsume(eq(key), eq(2L), anyLong(), anyLong(), anyLong(), anyLong(), any())).thenReturn(null);
+
+        cut.initialize();
+
+        // Two local consumes (capacity 10, same instant so no refill): local delta = 2, tokens = 8.
+        cut.refillAndTryConsume(key, 1, 1, 1_000L, 10, 1_000L, () -> new TokenBucket(key)).blockingGet();
+        cut.refillAndTryConsume(key, 1, 1, 1_000L, 10, 1_000L, () -> new TokenBucket(key)).blockingGet();
+
+        Thread.sleep(6_000); // wait for the ~5s reconcile scheduler to fire
+
+        verify(remoteCache).refillAndTryConsume(eq(key), eq(2L), anyLong(), anyLong(), anyLong(), anyLong(), any());
+
+        LocalTokenBucket local = localCache.get(key).blockingGet();
+        assertThat(local.getLocalConsumed()).isEqualTo(0); // delta cleared, not left to accumulate
+        assertThat(local.getTokens()).isEqualTo(8); // local bucket untouched: a no-op store does not re-anchor it
+    }
+}

--- a/gravitee-gateway-services-ratelimit/src/test/java/io/gravitee/gateway/services/ratelimit/DefaultTokenBucketRateLimitServiceTest.java
+++ b/gravitee-gateway-services-ratelimit/src/test/java/io/gravitee/gateway/services/ratelimit/DefaultTokenBucketRateLimitServiceTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.reactivex.rxjava3.core.Single;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class DefaultTokenBucketRateLimitServiceTest {
+
+    @Mock
+    private TokenBucketRateLimitRepository<TokenBucket> strictRepository;
+
+    @Mock
+    private TokenBucketRateLimitRepository<TokenBucket> asyncRepository;
+
+    private DefaultTokenBucketRateLimitService cut;
+
+    private final String key = "key1";
+
+    @BeforeEach
+    void setUp() {
+        cut = new DefaultTokenBucketRateLimitService();
+        cut.setTokenBucketRateLimitRepository(strictRepository);
+        cut.setAsyncTokenBucketRateLimitRepository(asyncRepository);
+    }
+
+    @Test
+    void routes_to_the_strict_repository_when_async_is_false() {
+        when(strictRepository.refillAndTryConsume(anyString(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any())).thenReturn(
+            Single.just(new TokenBucketConsumeResult(true, 4, 0))
+        );
+
+        TokenBucketConsumeResult result = cut
+            .refillAndTryConsume(key, 1, 1, 1_000L, 5, 1_000L, false, () -> new TokenBucket(key))
+            .blockingGet();
+
+        assertThat(result.remainingTokens()).isEqualTo(4);
+        verify(strictRepository).refillAndTryConsume(anyString(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any());
+        verify(asyncRepository, never()).refillAndTryConsume(anyString(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any());
+    }
+
+    @Test
+    void routes_to_the_async_repository_when_async_is_true() {
+        when(asyncRepository.refillAndTryConsume(anyString(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any())).thenReturn(
+            Single.just(new TokenBucketConsumeResult(true, 2, 0))
+        );
+
+        TokenBucketConsumeResult result = cut
+            .refillAndTryConsume(key, 1, 1, 1_000L, 5, 1_000L, true, () -> new TokenBucket(key))
+            .blockingGet();
+
+        assertThat(result.remainingTokens()).isEqualTo(2);
+        verify(asyncRepository).refillAndTryConsume(anyString(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any());
+        verify(strictRepository, never()).refillAndTryConsume(anyString(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any());
+    }
+
+    @Test
+    void wraps_a_synchronous_repository_failure_into_a_single_error() {
+        // A repository that throws synchronously (rather than returning Single.error) must not blow up the
+        // caller: the bridge wraps the throwable into Single.error so the reactive chain stays intact.
+        RuntimeException boom = new RuntimeException("boom");
+        when(strictRepository.refillAndTryConsume(anyString(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any())).thenThrow(
+            boom
+        );
+
+        cut
+            .refillAndTryConsume(key, 1, 1, 1_000L, 5, 1_000L, false, () -> new TokenBucket(key))
+            .test()
+            .assertError(boom);
+    }
+}

--- a/gravitee-gateway-services-ratelimit/src/test/java/io/gravitee/gateway/services/ratelimit/LocalTokenBucketRateLimitRepositoryTest.java
+++ b/gravitee-gateway-services-ratelimit/src/test/java/io/gravitee/gateway/services/ratelimit/LocalTokenBucketRateLimitRepositoryTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LocalTokenBucketRateLimitRepositoryTest {
+
+    private final LocalTokenBucketRateLimitRepository cut = new LocalTokenBucketRateLimitRepository();
+    private final String key = "key1";
+
+    @Test
+    void fresh_bucket_starts_full_and_consuming_one_token_records_a_local_delta() {
+        long now = 1_000L;
+
+        TokenBucketConsumeResult result = cut
+            .refillAndTryConsume(key, 1, 1, 1_000L, 5, now, () -> new LocalTokenBucket(new TokenBucket(key)))
+            .blockingGet();
+
+        assertThat(result.allowed()).isTrue();
+        assertThat(result.remainingTokens()).isEqualTo(4); // full bucket of 5, minus the one consumed
+
+        LocalTokenBucket stored = cut.get(key).blockingGet();
+        assertThat(stored.getLocalConsumed()).isEqualTo(1); // one token consumed locally, pending sync to the store
+    }
+
+    @Test
+    void rejected_request_does_not_count_toward_the_local_delta() {
+        long now = 1_000L; // same instant for every call: no refill, so the full bucket of 5 is the only budget
+        for (int i = 0; i < 5; i++) {
+            cut.refillAndTryConsume(key, 1, 1, 1_000L, 5, now, () -> new LocalTokenBucket(new TokenBucket(key))).blockingGet();
+        }
+
+        TokenBucketConsumeResult rejected = cut
+            .refillAndTryConsume(key, 1, 1, 1_000L, 5, now, () -> new LocalTokenBucket(new TokenBucket(key)))
+            .blockingGet();
+
+        assertThat(rejected.allowed()).isFalse();
+        assertThat(rejected.remainingTokens()).isEqualTo(0);
+
+        LocalTokenBucket stored = cut.get(key).blockingGet();
+        assertThat(stored.getLocalConsumed()).isEqualTo(5); // the 6th request was rejected and must not be owed to the store
+    }
+}


### PR DESCRIPTION
## What

Adds the async (non-strict) token-bucket path to `gravitee-gateway-services-ratelimit`, mirroring the existing async rate-limit machinery.

New classes:
- `LocalTokenBucket` — a node-local `TokenBucket` plus the locally-consumed delta (and the last-seen bucket parameters, replayed at reconcile). Analogue of `LocalRateLimit`.
- `LocalTokenBucketRateLimitRepository` — in-memory per-node bucket; refills/consumes via the shared `TokenBucketCalculator` (same algorithm as the strict backends), no store round-trip. Analogue of `LocalRateLimitRepository`.
- `AsyncTokenBucketRateLimitRepository` — fast local path + a ~5s scheduler that reconciles each touched key's consumed delta to the store as one batched consume, then adopts the store's authoritative remaining. Analogue of `AsyncRateLimitRepository`.
- `DefaultTokenBucketRateLimitService` — bridge that routes the `async` flag to strict vs async. Analogue of `DefaultRateLimitService`.

`AsyncRateLimitService.doStart()` now also registers a `TokenBucketRateLimitService` singleton (guarded by the presence of a token-bucket repository so an older repository plugin can't break rate-limit async).

## Trade-off

Non-strict / eventually consistent: each node runs its own local bucket, so across N nodes a backend may receive more than the configured rate, in exchange for far fewer store round-trips. `async=false` (the policy default, PR3) keeps today's strict, exact behaviour.

## Tests

TDD, 6 new unit tests (local consume + delta accounting, service routing, async fast-path, 5s reconcile). `mvn -pl gravitee-gateway-services-ratelimit test` → 8 passed (incl. the 2 existing rate-limit tests, no regression).

Part of APIM-14499. Stacked on #141 (APIM-14484 policy) and depends on the `TokenBucketRateLimitService` SPI (gravitee-api-management #18082).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-wba-APIM-14499-token-bucket-async-service-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/5.0.0-wba-APIM-14499-token-bucket-async-service-SNAPSHOT/gravitee-ratelimit-parent-5.0.0-wba-APIM-14499-token-bucket-async-service-SNAPSHOT.zip)
  <!-- Version placeholder end -->
