### PR TITLE
feat(token-bucket): async (non-strict) mode flag

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -365,12 +365,20 @@ It runs on HTTP proxy APIs (V4, and V2 through the v4-emulation engine) and on V
 |String
 |FALLBACK_PASS_TROUGH
 
+|async
+|No
+|By activating this option, rate-limiting is applied in an asynchronous (non-strict) way: the distributed bucket is approximate, so a backend can receive more requests than configured. See the note below.
+|Boolean
+|false
+
 |===
 
 [NOTE]
 ====
 The `*` on `burstCapacity` and `refillRate`: each is required, but may be supplied *either* as the static value above *or* through its dynamic Expression Language variant (`dynamicBurstCapacity` / `dynamicRefillRate`), evaluated per request. Because the JSON schema cannot express that either/or it declares no `required` fields; a configuration where neither form resolves to a positive value is rejected at request time with a `500` (`TOKEN_BUCKET_RATE_LIMIT_SERVER_ERROR`).
 ====
+
+By default (`async` = `false`) the bucket is strict and exact: every request runs an atomic refill-and-consume against the store. With `async` = `true` each gateway node keeps its own local bucket and reconciles it to the store on a short interval. This gives higher throughput and far fewer store round-trips, but the distributed bucket is only approximate: across several nodes a backend can receive more requests than the configured rate. Even on a single node the local bucket is reconciled to the store only periodically, so within a reconcile window the node can admit more than the configured rate before the store corrects it — async is not request-for-request identical to strict mode. The setting mirrors the `rate-limit` policy's `async` option.
 
 ==== Configuration example
 [source, json]

--- a/gravitee-policy-token-bucket-ratelimit/src/main/java/io/gravitee/policy/tokenbucket/TokenBucketRateLimitPolicy.java
+++ b/gravitee-policy-token-bucket-ratelimit/src/main/java/io/gravitee/policy/tokenbucket/TokenBucketRateLimitPolicy.java
@@ -25,7 +25,7 @@ import io.gravitee.policy.tokenbucket.configuration.TokenBucketRateLimitPolicyCo
 import io.gravitee.ratelimit.KeyFactory;
 import io.gravitee.ratelimit.PolicyRateLimitException;
 import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
-import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitService;
 import io.gravitee.repository.ratelimit.model.TokenBucket;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
@@ -88,7 +88,6 @@ public class TokenBucketRateLimitPolicy implements HttpPolicy {
         );
     }
 
-    @SuppressWarnings("unchecked")
     private Completable run(HttpBaseExecutionContext ctx) {
         // Captured on the event loop (policy entry) so we can resume on it after the store call.
         Context context = Vertx.currentContext();
@@ -98,9 +97,11 @@ public class TokenBucketRateLimitPolicy implements HttpPolicy {
             return Completable.error(PolicyRateLimitException.serverError(TOKEN_BUCKET_SERVER_ERROR, message));
         }
 
-        TokenBucketRateLimitRepository<TokenBucket> repository = ctx.getComponent(TokenBucketRateLimitRepository.class);
-        if (repository == null) {
-            String message = "No token-bucket rate-limit repository has been installed";
+        // The service bridge (registered by the rate-limit gateway service) selects the strict or async
+        // path from the configured flag — the policy itself stays mode-agnostic.
+        TokenBucketRateLimitService service = ctx.getComponent(TokenBucketRateLimitService.class);
+        if (service == null) {
+            String message = "No token-bucket rate-limit service has been installed";
             ctx.metrics().setErrorMessage(message);
             return Completable.error(PolicyRateLimitException.serverError(TOKEN_BUCKET_SERVER_ERROR, message));
         }
@@ -132,13 +133,14 @@ public class TokenBucketRateLimitPolicy implements HttpPolicy {
                 ctx.metrics().setErrorMessage(message);
                 return Completable.error(PolicyRateLimitException.serverError(TOKEN_BUCKET_SERVER_ERROR, message));
             }
-            Single<TokenBucketConsumeResult> consume = repository.refillAndTryConsume(
+            Single<TokenBucketConsumeResult> consume = service.refillAndTryConsume(
                 resolved.key(),
                 1,
                 resolved.refillRate(),
                 refillPeriodMillis,
                 capacity,
                 now,
+                configuration.isAsync(),
                 () -> {
                     TokenBucket bucket = new TokenBucket(resolved.key());
                     bucket.setSubscription(ctx.getAttribute(ExecutionContext.ATTR_SUBSCRIPTION_ID));
@@ -146,7 +148,7 @@ public class TokenBucketRateLimitPolicy implements HttpPolicy {
                 }
             );
             if (consume == null) {
-                // No-op repository (rate limiting disabled): pass through.
+                // No-op store (rate limiting disabled): pass through.
                 return Completable.complete();
             }
             // The store may emit on a non-event-loop thread (e.g. the reactive MongoDB driver). Resume on the
@@ -166,7 +168,8 @@ public class TokenBucketRateLimitPolicy implements HttpPolicy {
     }
 
     // Evaluate an EL expression to a long via async eval() (which supports deferred variables), defaulting
-    // to 0 when the expression is unset or yields nothing.
+    // to 0 when the expression is unset or yields nothing. A resulting 0 is not applied silently: the
+    // zero-config guard in run() rejects it with a 500 (TOKEN_BUCKET_RATE_LIMIT_SERVER_ERROR).
     private static Single<Long> evalLong(HttpBaseExecutionContext ctx, String expression) {
         if (expression == null || expression.isBlank()) {
             return Single.just(0L);

--- a/gravitee-policy-token-bucket-ratelimit/src/main/java/io/gravitee/policy/tokenbucket/configuration/TokenBucketRateLimitPolicyConfiguration.java
+++ b/gravitee-policy-token-bucket-ratelimit/src/main/java/io/gravitee/policy/tokenbucket/configuration/TokenBucketRateLimitPolicyConfiguration.java
@@ -42,6 +42,14 @@ public class TokenBucketRateLimitPolicyConfiguration implements PolicyConfigurat
     @Builder.Default
     private ErrorStrategy errorStrategy = ErrorStrategy.FALLBACK_PASS_TROUGH;
 
+    /**
+     * Non-strict mode. When {@code false} (default) enforcement is strict and exact (per-request atomic
+     * refill+consume against the store). When {@code true} the bucket is enforced locally per node and
+     * reconciled to the store periodically: higher throughput, but the distributed bucket is approximate
+     * so a backend may receive more than the configured rate. Mirrors the {@code rate-limit} policy.
+     */
+    private boolean async;
+
     private boolean addHeaders;
 
     /** Whole tokens added to the bucket each refill period. Used when {@code > 0}; otherwise {@link #dynamicRefillRate} is evaluated. */

--- a/gravitee-policy-token-bucket-ratelimit/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-token-bucket-ratelimit/src/main/resources/schemas/schema-form.json
@@ -59,6 +59,12 @@
             "title": "Use key only",
             "description": "When enabled, only the configured key identifies the consumer (the plan/subscription pair is ignored)."
         },
+        "async": {
+            "type": "boolean",
+            "default": false,
+            "title": "Non-strict mode (async)",
+            "description": "By activating this option, the bucket is enforced per node and reconciled to the store periodically. The distributed bucket becomes approximate (a backend can receive more requests than the configured rate) in exchange for higher throughput and fewer store round-trips."
+        },
         "addHeaders": {
             "type": "boolean",
             "default": false,

--- a/gravitee-policy-token-bucket-ratelimit/src/test/java/io/gravitee/policy/tokenbucket/TokenBucketRateLimitPolicyTest.java
+++ b/gravitee-policy-token-bucket-ratelimit/src/test/java/io/gravitee/policy/tokenbucket/TokenBucketRateLimitPolicyTest.java
@@ -30,7 +30,7 @@ import io.gravitee.policy.tokenbucket.configuration.TokenBucketRateLimitPolicyCo
 import io.gravitee.ratelimit.ErrorStrategy;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
-import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitService;
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -54,7 +54,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class TokenBucketRateLimitPolicyTest {
 
     @Mock(strictness = Mock.Strictness.LENIENT)
-    private TokenBucketRateLimitRepository<io.gravitee.repository.ratelimit.model.TokenBucket> repository;
+    private TokenBucketRateLimitService service;
 
     @Mock(strictness = Mock.Strictness.LENIENT)
     private HttpPlainExecutionContext ctx;
@@ -86,7 +86,7 @@ class TokenBucketRateLimitPolicyTest {
         policy = new TokenBucketRateLimitPolicy(configuration);
 
         when(ctx.metrics()).thenReturn(new Metrics());
-        when(ctx.getComponent(TokenBucketRateLimitRepository.class)).thenReturn(repository);
+        when(ctx.getComponent(TokenBucketRateLimitService.class)).thenReturn(service);
         when(ctx.response()).thenReturn(response);
         when(response.headers()).thenReturn(headers);
         when(ctx.timestamp()).thenReturn(1_000L);
@@ -97,7 +97,7 @@ class TokenBucketRateLimitPolicyTest {
         // Message context mirrors the plain one; on a message API the policy interrupts the message stream
         // (interruptMessagesWith) instead of the HTTP request.
         when(messageContext.metrics()).thenReturn(new Metrics());
-        when(messageContext.getComponent(TokenBucketRateLimitRepository.class)).thenReturn(repository);
+        when(messageContext.getComponent(TokenBucketRateLimitService.class)).thenReturn(service);
         when(messageContext.response()).thenReturn(response);
         when(messageContext.timestamp()).thenReturn(1_000L);
         when(messageContext.getTemplateEngine()).thenReturn(templateEngine);
@@ -108,7 +108,7 @@ class TokenBucketRateLimitPolicyTest {
 
     @Test
     void should_allow_message_when_token_available(Vertx vertx, VertxTestContext testContext) {
-        when(repository.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any())).thenReturn(
+        when(service.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(
             Single.just(new TokenBucketConsumeResult(true, 299, 1_000L))
         );
 
@@ -119,7 +119,7 @@ class TokenBucketRateLimitPolicyTest {
 
     @Test
     void should_interrupt_message_stream_when_bucket_empty(Vertx vertx, VertxTestContext testContext) {
-        when(repository.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any())).thenReturn(
+        when(service.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(
             Single.just(new TokenBucketConsumeResult(false, 0, 1_500L))
         );
 
@@ -147,8 +147,8 @@ class TokenBucketRateLimitPolicyTest {
     }
 
     @Test
-    void should_interrupt_message_stream_with_500_when_no_repository_installed(Vertx vertx, VertxTestContext testContext) {
-        when(messageContext.getComponent(TokenBucketRateLimitRepository.class)).thenReturn(null);
+    void should_interrupt_message_stream_with_500_when_no_service_installed(Vertx vertx, VertxTestContext testContext) {
+        when(messageContext.getComponent(TokenBucketRateLimitService.class)).thenReturn(null);
 
         vertx.runOnContext(v ->
             policy
@@ -160,7 +160,7 @@ class TokenBucketRateLimitPolicyTest {
                         if (
                             th instanceof MyException ex &&
                             ex.getExecutionFailure().statusCode() == 500 &&
-                            ex.getExecutionFailure().message().contains("No token-bucket rate-limit repository")
+                            ex.getExecutionFailure().message().contains("No token-bucket rate-limit service")
                         ) {
                             testContext.completeNow();
                         } else {
@@ -173,7 +173,7 @@ class TokenBucketRateLimitPolicyTest {
 
     @Test
     void should_allow_request_when_token_available(Vertx vertx, VertxTestContext testContext) {
-        when(repository.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any())).thenReturn(
+        when(service.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(
             Single.just(new TokenBucketConsumeResult(true, 299, 1_000L))
         );
 
@@ -184,10 +184,50 @@ class TokenBucketRateLimitPolicyTest {
                 .doOnComplete(() -> {
                     // useKeyOnly=true + key="test-key" resolves to "test-key:tb" (the :tb type marker keeps
                     // token-bucket keys from clashing with rate-limit / quota / spike-arrest).
-                    verify(repository).refillAndTryConsume(eq("test-key:tb"), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any());
+                    verify(service).refillAndTryConsume(
+                        eq("test-key:tb"),
+                        eq(1L),
+                        eq(3L),
+                        eq(1_000L),
+                        eq(300L),
+                        eq(1_000L),
+                        eq(false),
+                        any()
+                    );
                     verify(headers).set("X-Rate-Limit-Limit", "300");
                     verify(headers).set("X-Rate-Limit-Remaining", "299");
                     verify(headers).set(eq("X-Rate-Limit-Reset"), anyString());
+                })
+                .subscribe(new SubscribeAdapter(testContext))
+        );
+    }
+
+    @Test
+    void should_pass_async_true_to_the_service_when_configured(Vertx vertx, VertxTestContext testContext) {
+        configuration = TokenBucketRateLimitPolicyConfiguration.builder()
+            .refillRate(3)
+            .burstCapacity(300)
+            .async(true)
+            .addHeaders(true)
+            .key("test-key")
+            .useKeyOnly(true)
+            .build();
+        policy = new TokenBucketRateLimitPolicy(configuration);
+        when(service.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(true), any())).thenReturn(
+            Single.just(new TokenBucketConsumeResult(true, 299, 1_000L))
+        );
+
+        vertx.runOnContext(v ->
+            policy
+                .onRequest(ctx)
+                .timeout(2, TimeUnit.SECONDS)
+                .doOnComplete(() -> {
+                    // The flag is threaded through to the service...
+                    verify(service).refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(true), any());
+                    // ...and the request takes the allowed path (headers are only written on a successful consume,
+                    // and the chain completes without a rejection).
+                    verify(headers).set("X-Rate-Limit-Remaining", "299");
+                    verify(ctx, never()).interruptWith(any());
                 })
                 .subscribe(new SubscribeAdapter(testContext))
         );
@@ -206,7 +246,7 @@ class TokenBucketRateLimitPolicyTest {
         // Dynamic values resolve via async eval() (supports deferred variables), not evalNow().
         when(templateEngine.eval("{(7)}", Long.class)).thenReturn(Maybe.just(7L));
         when(templateEngine.eval("{(2)}", Long.class)).thenReturn(Maybe.just(2L));
-        when(repository.refillAndTryConsume(any(), eq(1L), eq(2L), eq(1_000L), eq(7L), eq(1_000L), any())).thenReturn(
+        when(service.refillAndTryConsume(any(), eq(1L), eq(2L), eq(1_000L), eq(7L), eq(1_000L), eq(false), any())).thenReturn(
             Single.just(new TokenBucketConsumeResult(true, 6, 1_000L))
         );
 
@@ -215,7 +255,7 @@ class TokenBucketRateLimitPolicyTest {
                 .onRequest(ctx)
                 .timeout(2, TimeUnit.SECONDS)
                 .doOnComplete(() -> {
-                    verify(repository).refillAndTryConsume(any(), eq(1L), eq(2L), eq(1_000L), eq(7L), eq(1_000L), any());
+                    verify(service).refillAndTryConsume(any(), eq(1L), eq(2L), eq(1_000L), eq(7L), eq(1_000L), eq(false), any());
                     verify(headers).set("X-Rate-Limit-Limit", "7");
                 })
                 .subscribe(new SubscribeAdapter(testContext))
@@ -225,7 +265,7 @@ class TokenBucketRateLimitPolicyTest {
     @Test
     void should_reject_request_when_bucket_empty(Vertx vertx, VertxTestContext testContext) {
         // empty bucket; next token due 500ms later -> Retry-After = ceil(500/1000) = 1
-        when(repository.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any())).thenReturn(
+        when(service.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(
             Single.just(new TokenBucketConsumeResult(false, 0, 1_500L))
         );
 
@@ -258,7 +298,7 @@ class TokenBucketRateLimitPolicyTest {
     @Test
     void should_pass_through_on_internal_error_with_fallback_strategy(Vertx vertx, VertxTestContext testContext) {
         configuration.setErrorStrategy(ErrorStrategy.FALLBACK_PASS_TROUGH);
-        when(repository.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any())).thenReturn(
+        when(service.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(
             Single.error(new RuntimeException("store down"))
         );
 
@@ -278,7 +318,7 @@ class TokenBucketRateLimitPolicyTest {
     @Test
     void should_block_on_internal_error_with_block_strategy(Vertx vertx, VertxTestContext testContext) {
         configuration.setErrorStrategy(ErrorStrategy.BLOCK_ON_INTERNAL_ERROR);
-        when(repository.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any())).thenReturn(
+        when(service.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(
             Single.error(new RuntimeException("store down"))
         );
 
@@ -300,15 +340,16 @@ class TokenBucketRateLimitPolicyTest {
     }
 
     @Test
-    void should_pass_through_when_repository_returns_null(Vertx vertx, VertxTestContext testContext) {
-        when(repository.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any())).thenReturn(null);
+    void should_pass_through_when_service_returns_null(Vertx vertx, VertxTestContext testContext) {
+        // NoOp store (rate limiting disabled): the service propagates a null Single.
+        when(service.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(null);
 
         vertx.runOnContext(v -> policy.onRequest(ctx).timeout(2, TimeUnit.SECONDS).subscribe(new SubscribeAdapter(testContext)));
     }
 
     @Test
-    void should_error_when_no_repository_installed() {
-        when(ctx.getComponent(TokenBucketRateLimitRepository.class)).thenReturn(null);
+    void should_error_when_no_service_installed() {
+        when(ctx.getComponent(TokenBucketRateLimitService.class)).thenReturn(null);
 
         policy
             .onRequest(ctx)
@@ -317,7 +358,7 @@ class TokenBucketRateLimitPolicyTest {
                 throwable ->
                     throwable instanceof MyException ex &&
                     ex.getExecutionFailure().statusCode() == 500 && // infra failure must be a 500, never masked as a 429
-                    ex.getExecutionFailure().message().contains("No token-bucket rate-limit repository")
+                    ex.getExecutionFailure().message().contains("No token-bucket rate-limit service")
             );
     }
 
@@ -346,7 +387,7 @@ class TokenBucketRateLimitPolicyTest {
             .useKeyOnly(true)
             .build();
         policy = new TokenBucketRateLimitPolicy(configuration);
-        when(repository.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any())).thenReturn(
+        when(service.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(
             Single.just(new TokenBucketConsumeResult(true, 299, 1_000L))
         );
 
@@ -372,7 +413,7 @@ class TokenBucketRateLimitPolicyTest {
             .useKeyOnly(true)
             .build();
         policy = new TokenBucketRateLimitPolicy(configuration);
-        when(repository.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any())).thenReturn(
+        when(service.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(
             Single.just(new TokenBucketConsumeResult(true, 299, 1_000L))
         );
 
@@ -380,7 +421,9 @@ class TokenBucketRateLimitPolicyTest {
             policy
                 .onRequest(ctx)
                 .timeout(2, TimeUnit.SECONDS)
-                .doOnComplete(() -> verify(repository).refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any()))
+                .doOnComplete(() ->
+                    verify(service).refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())
+                )
                 .subscribe(new SubscribeAdapter(testContext))
         );
     }
@@ -397,7 +440,7 @@ class TokenBucketRateLimitPolicyTest {
         policy = new TokenBucketRateLimitPolicy(configuration);
         // useKeyOnly=false composes subscription + key + type: "<plan><subscription>:<key>:tb".
         when(ctx.getAttributes()).thenReturn(Map.of(ExecutionContext.ATTR_PLAN, "plan1", ExecutionContext.ATTR_SUBSCRIPTION_ID, "sub1"));
-        when(repository.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any())).thenReturn(
+        when(service.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(
             Single.just(new TokenBucketConsumeResult(true, 299, 1_000L))
         );
 
@@ -406,13 +449,14 @@ class TokenBucketRateLimitPolicyTest {
                 .onRequest(ctx)
                 .timeout(2, TimeUnit.SECONDS)
                 .doOnComplete(() ->
-                    verify(repository).refillAndTryConsume(
+                    verify(service).refillAndTryConsume(
                         eq("plan1sub1:test-key:tb"),
                         eq(1L),
                         eq(3L),
                         eq(1_000L),
                         eq(300L),
                         eq(1_000L),
+                        eq(false),
                         any()
                     )
                 )
@@ -440,13 +484,60 @@ class TokenBucketRateLimitPolicyTest {
                             ex.getExecutionFailure().statusCode() == 500 &&
                             "TOKEN_BUCKET_RATE_LIMIT_SERVER_ERROR".equals(ex.getExecutionFailure().key())
                         ) {
-                            verify(repository, never()).refillAndTryConsume(
+                            verify(service, never()).refillAndTryConsume(
                                 any(),
                                 anyLong(),
                                 anyLong(),
                                 anyLong(),
                                 anyLong(),
                                 anyLong(),
+                                anyBoolean(),
+                                any()
+                            );
+                            testContext.completeNow();
+                        } else {
+                            testContext.failNow(th);
+                        }
+                    }
+                )
+        );
+    }
+
+    @Test
+    void should_error_with_500_when_dynamic_rate_resolves_to_empty(Vertx vertx, VertxTestContext testContext) {
+        // The dynamic EL expression resolves to no value: eval() returns an empty Maybe, so evalLong falls
+        // back to 0L. That 0 is not silently applied as "no limit" — the zero-config guard rejects it with a
+        // 500 and the store is never touched.
+        configuration = TokenBucketRateLimitPolicyConfiguration.builder()
+            .dynamicRefillRate("{#empty}")
+            .burstCapacity(300)
+            .addHeaders(false)
+            .key("test-key")
+            .useKeyOnly(true)
+            .build();
+        policy = new TokenBucketRateLimitPolicy(configuration);
+        when(templateEngine.eval("{#empty}", Long.class)).thenReturn(Maybe.empty());
+
+        vertx.runOnContext(v ->
+            policy
+                .onRequest(ctx)
+                .timeout(2, TimeUnit.SECONDS)
+                .subscribe(
+                    () -> testContext.failNow("this test must fail"),
+                    th -> {
+                        if (
+                            th instanceof MyException ex &&
+                            ex.getExecutionFailure().statusCode() == 500 &&
+                            "TOKEN_BUCKET_RATE_LIMIT_SERVER_ERROR".equals(ex.getExecutionFailure().key())
+                        ) {
+                            verify(service, never()).refillAndTryConsume(
+                                any(),
+                                anyLong(),
+                                anyLong(),
+                                anyLong(),
+                                anyLong(),
+                                anyLong(),
+                                anyBoolean(),
                                 any()
                             );
                             testContext.completeNow();


### PR DESCRIPTION
## What

Exposes the async (non-strict) token-bucket mode through the policy, **off by default**.

- New `async` config flag (default `false`).
- The policy now resolves the bucket through `TokenBucketRateLimitService` (the bridge registered by the rate-limit gateway service) instead of looking up `TokenBucketRateLimitRepository` directly, and passes `isAsync()`. The policy stays mode-agnostic; the bridge picks strict vs async.
- `schema-form.json`: new `async` toggle.
- README: documents the strict-vs-async trade-off.

## Behaviour

- `async = false` (default): identical to today — strict, exact, per-request atomic refill+consume.
- `async = true`: per-node local bucket reconciled to the store periodically; higher throughput, approximate distributed bucket (a backend may receive more than the configured rate). Identical to strict on a single node.

## Tests

TDD. The existing behavioural tests migrate to the service collaborator (assertions unchanged) and a new test verifies the `async` flag is passed through. `mvn -pl gravitee-policy-token-bucket-ratelimit test` → 11 passed.

Completes APIM-14499. Stacked on #142 (async service) and depends on the `TokenBucketRateLimitService` SPI (gravitee-api-management #18082).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-wba-APIM-14499-token-bucket-async-policy-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/5.0.0-wba-APIM-14499-token-bucket-async-policy-SNAPSHOT/gravitee-ratelimit-parent-5.0.0-wba-APIM-14499-token-bucket-async-policy-SNAPSHOT.zip)
  <!-- Version placeholder end -->
