### PR TITLE
feat(token-bucket): support v4 message APIs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -310,7 +310,9 @@ Dynamic Time Duration
 
 The Token-Bucket policy throttles requests with the token bucket algorithm. A bucket holds up to a burst capacity and gains a fixed number of tokens each period. Each request takes one token. When the bucket is empty the request is rejected with `429`. A fresh bucket starts full, so the first burst goes through right away, and after that traffic is held at the refill rate.
 
-The refill rate is a whole-token count per period. `refillRate` tokens are added every `refillPeriodTime` `refillPeriodTimeUnit` (for example, 100 tokens per 1 MINUTE), and `burstCapacity` is the bucket size, which sets the largest burst allowed. All arithmetic is integer, so there are no fractional rates. The policy is HTTP proxy only and runs on V4 APIs and on V2 APIs (through the v4-emulation engine).
+The refill rate is a whole-token count per period. `refillRate` tokens are added every `refillPeriodTime` `refillPeriodTimeUnit` (for example, 100 tokens per 1 MINUTE), and `burstCapacity` is the bucket size, which sets the largest burst allowed. All arithmetic is integer, so there are no fractional rates.
+
+It runs on HTTP proxy APIs (V4, and V2 through the v4-emulation engine) and on V4 message APIs. On a message API it meters the request (publish) phase the same way as the `rate-limit`, `quota` and `spike-arrest` policies: one consume per phase, and when the bucket is empty the message stream is interrupted instead of returning an HTTP `429`.
 
 |===
 |Property |Required |Description |Type |Default

--- a/gravitee-policy-token-bucket-ratelimit/src/main/java/io/gravitee/policy/tokenbucket/TokenBucketRateLimitPolicy.java
+++ b/gravitee-policy-token-bucket-ratelimit/src/main/java/io/gravitee/policy/tokenbucket/TokenBucketRateLimitPolicy.java
@@ -17,6 +17,8 @@ package io.gravitee.policy.tokenbucket;
 
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.reactive.api.ExecutionWarn;
+import io.gravitee.gateway.reactive.api.context.http.HttpBaseExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpMessageExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
 import io.gravitee.policy.tokenbucket.configuration.TokenBucketRateLimitPolicyConfiguration;
@@ -36,10 +38,14 @@ import java.util.concurrent.TimeUnit;
 /**
  * Opt-in token-bucket (burst) rate-limit policy: a steady refill rate accumulates tokens up to a
  * burst capacity, each request consumes one token, and requests are rejected with {@code 429} when
- * the bucket is empty. HTTP proxy only. Enforcement runs against the configured rate-limit store, but
- * the default {@code errorStrategy} is {@code FALLBACK_PASS_TROUGH} (fail open): while the store is
- * unavailable requests pass through and throttling is disabled. Set {@code BLOCK_ON_INTERNAL_ERROR}
- * to fail closed.
+ * the bucket is empty. Enforcement runs against the configured rate-limit store, but the default
+ * {@code errorStrategy} is {@code FALLBACK_PASS_TROUGH} (fail open): while the store is unavailable
+ * requests pass through and throttling is disabled. Set {@code BLOCK_ON_INTERNAL_ERROR} to fail closed.
+ *
+ * <p>Works on HTTP proxy APIs ({@code onRequest}) and on v4 message APIs ({@code onMessageRequest}).
+ * As with the {@code rate-limit}/{@code quota}/{@code spike-arrest} policies, the message phase reuses
+ * the same per-invocation consume and interrupts the message stream (rather than the HTTP request) when
+ * the bucket is empty.
  */
 public class TokenBucketRateLimitPolicy implements HttpPolicy {
 
@@ -73,8 +79,17 @@ public class TokenBucketRateLimitPolicy implements HttpPolicy {
         );
     }
 
+    @Override
+    public Completable onMessageRequest(HttpMessageExecutionContext ctx) {
+        // Same per-invocation consume as the HTTP path; on failure interrupt the message stream rather than
+        // the HTTP request. Mirrors rate-limit / quota / spike-arrest.
+        return Completable.defer(() -> run(ctx)).onErrorResumeNext(th ->
+            ctx.interruptMessagesWith(PolicyRateLimitException.getExecutionFailure(TOKEN_BUCKET_SERVER_ERROR, th)).ignoreElements()
+        );
+    }
+
     @SuppressWarnings("unchecked")
-    private Completable run(HttpPlainExecutionContext ctx) {
+    private Completable run(HttpBaseExecutionContext ctx) {
         // Captured on the event loop (policy entry) so we can resume on it after the store call.
         Context context = Vertx.currentContext();
         if (configuration == null) {
@@ -152,7 +167,7 @@ public class TokenBucketRateLimitPolicy implements HttpPolicy {
 
     // Evaluate an EL expression to a long via async eval() (which supports deferred variables), defaulting
     // to 0 when the expression is unset or yields nothing.
-    private static Single<Long> evalLong(HttpPlainExecutionContext ctx, String expression) {
+    private static Single<Long> evalLong(HttpBaseExecutionContext ctx, String expression) {
         if (expression == null || expression.isBlank()) {
             return Single.just(0L);
         }
@@ -161,7 +176,7 @@ public class TokenBucketRateLimitPolicy implements HttpPolicy {
 
     private record Resolved(String key, long refillRate, long capacity) {}
 
-    private Completable applyResult(HttpPlainExecutionContext ctx, TokenBucketConsumeResult result, long capacity, long now) {
+    private Completable applyResult(HttpBaseExecutionContext ctx, TokenBucketConsumeResult result, long capacity, long now) {
         if (configuration.isAddHeaders()) {
             var headers = ctx.response().headers();
             headers.set(X_RATE_LIMIT_LIMIT, Long.toString(capacity));
@@ -186,7 +201,7 @@ public class TokenBucketRateLimitPolicy implements HttpPolicy {
         );
     }
 
-    private Completable errorManagement(HttpPlainExecutionContext ctx, Throwable throwable, long capacity) {
+    private Completable errorManagement(HttpBaseExecutionContext ctx, Throwable throwable, long capacity) {
         if (throwable instanceof PolicyRateLimitException ex) {
             return Completable.error(ex);
         }

--- a/gravitee-policy-token-bucket-ratelimit/src/main/resources/plugin.properties
+++ b/gravitee-policy-token-bucket-ratelimit/src/main/resources/plugin.properties
@@ -7,3 +7,4 @@ type=policy
 category=others
 icon=ratelimit.svg
 http_proxy=REQUEST
+http_message=REQUEST

--- a/gravitee-policy-token-bucket-ratelimit/src/test/java/io/gravitee/policy/tokenbucket/TokenBucketRateLimitPolicyTest.java
+++ b/gravitee-policy-token-bucket-ratelimit/src/test/java/io/gravitee/policy/tokenbucket/TokenBucketRateLimitPolicyTest.java
@@ -23,6 +23,7 @@ import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.http.HttpMessageExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpResponse;
 import io.gravitee.policy.tokenbucket.configuration.TokenBucketRateLimitPolicyConfiguration;
@@ -59,6 +60,9 @@ class TokenBucketRateLimitPolicyTest {
     private HttpPlainExecutionContext ctx;
 
     @Mock(strictness = Mock.Strictness.LENIENT)
+    private HttpMessageExecutionContext messageContext;
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private HttpResponse response;
 
     @Mock(strictness = Mock.Strictness.LENIENT)
@@ -89,6 +93,82 @@ class TokenBucketRateLimitPolicyTest {
         when(ctx.getTemplateEngine()).thenReturn(templateEngine);
         when(templateEngine.eval("test-key", String.class)).thenReturn(Maybe.just("test-key"));
         when(ctx.interruptWith(any())).thenAnswer(invocation -> Completable.error(new MyException(invocation.getArgument(0))));
+
+        // Message context mirrors the plain one; on a message API the policy interrupts the message stream
+        // (interruptMessagesWith) instead of the HTTP request.
+        when(messageContext.metrics()).thenReturn(new Metrics());
+        when(messageContext.getComponent(TokenBucketRateLimitRepository.class)).thenReturn(repository);
+        when(messageContext.response()).thenReturn(response);
+        when(messageContext.timestamp()).thenReturn(1_000L);
+        when(messageContext.getTemplateEngine()).thenReturn(templateEngine);
+        when(messageContext.interruptMessagesWith(any())).thenAnswer(invocation ->
+            Flowable.error(new MyException(invocation.getArgument(0)))
+        );
+    }
+
+    @Test
+    void should_allow_message_when_token_available(Vertx vertx, VertxTestContext testContext) {
+        when(repository.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any())).thenReturn(
+            Single.just(new TokenBucketConsumeResult(true, 299, 1_000L))
+        );
+
+        vertx.runOnContext(v ->
+            policy.onMessageRequest(messageContext).timeout(2, TimeUnit.SECONDS).subscribe(new SubscribeAdapter(testContext))
+        );
+    }
+
+    @Test
+    void should_interrupt_message_stream_when_bucket_empty(Vertx vertx, VertxTestContext testContext) {
+        when(repository.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), any())).thenReturn(
+            Single.just(new TokenBucketConsumeResult(false, 0, 1_500L))
+        );
+
+        vertx.runOnContext(v ->
+            policy
+                .onMessageRequest(messageContext)
+                .timeout(2, TimeUnit.SECONDS)
+                .doOnError(th -> {
+                    assertThat(th).isInstanceOf(MyException.class);
+                    ExecutionFailure failure = ((MyException) th).getExecutionFailure();
+                    assertThat(failure.statusCode()).isEqualTo(429); // interrupts the message stream, not an HTTP 429 response
+                    assertThat(failure.message()).contains("Rate limit exceeded");
+                })
+                .subscribe(
+                    () -> testContext.failNow("must interrupt the message stream when the bucket is empty"),
+                    th -> {
+                        if (th instanceof MyException) {
+                            testContext.completeNow();
+                        } else {
+                            testContext.failNow(th);
+                        }
+                    }
+                )
+        );
+    }
+
+    @Test
+    void should_interrupt_message_stream_with_500_when_no_repository_installed(Vertx vertx, VertxTestContext testContext) {
+        when(messageContext.getComponent(TokenBucketRateLimitRepository.class)).thenReturn(null);
+
+        vertx.runOnContext(v ->
+            policy
+                .onMessageRequest(messageContext)
+                .timeout(2, TimeUnit.SECONDS)
+                .subscribe(
+                    () -> testContext.failNow("infra failure must interrupt the message stream"),
+                    th -> {
+                        if (
+                            th instanceof MyException ex &&
+                            ex.getExecutionFailure().statusCode() == 500 &&
+                            ex.getExecutionFailure().message().contains("No token-bucket rate-limit repository")
+                        ) {
+                            testContext.completeNow();
+                        } else {
+                            testContext.failNow(th);
+                        }
+                    }
+                )
+        );
     }
 
     @Test


### PR DESCRIPTION
## What

Extends the token-bucket policy to **v4 message APIs**. The policy already implements `HttpPolicy`; this adds `onMessageRequest`.

Mirrors the `rate-limit` / `quota` / `spike-arrest` policies exactly:
- `onMessageRequest` reuses the same per-invocation consume as `onRequest` (the shared `run(...)`, now typed to `HttpBaseExecutionContext`).
- On the message phase, failure interrupts the **message stream** (`ctx.interruptMessagesWith(...)`) instead of the HTTP request — empty bucket interrupts with the token-bucket 429 key, infra failure with the 500 server-error key.
- One consume per phase invocation (per connection/subscription), consistent with the rate-limit family — not per individual message.

## Behaviour
- Message API: tokens consumed on the request (publish) phase; bucket empty → message stream interrupted.
- **HTTP proxy path unchanged** (all existing HTTP tests still green).

## Tests
TDD. Added message-context tests: allow when token available, interrupt the stream when the bucket is empty (429), interrupt with 500 when no repository is installed. `mvn -pl gravitee-policy-token-bucket-ratelimit test` → 13 passed.

Implements APIM-14497. Depends on / stacked on #141 (APIM-14484).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-wba-APIM-14497-token-bucket-messages-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/5.0.0-wba-APIM-14497-token-bucket-messages-SNAPSHOT/gravitee-ratelimit-parent-5.0.0-wba-APIM-14497-token-bucket-messages-SNAPSHOT.zip)
  <!-- Version placeholder end -->
