### PR TITLE
feat(ratelimit): tunable async flush interval

### DIFF
--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitRepository.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitRepository.java
@@ -39,14 +39,24 @@ public class AsyncRateLimitRepository implements RateLimitRepository<RateLimit> 
 
     private static final Long LOCK_TIMEOUT_MILLIS = 250L;
 
+    /** Default reconcile interval, preserved from the original hardcoded value. */
+    public static final long DEFAULT_FLUSH_INTERVAL_MILLIS = 5000L;
+
     private final Set<String> keys = new CopyOnWriteArraySet<>();
     private final SharedData sharedData;
     private LocalRateLimitRepository localCacheRateLimitRepository;
     private RateLimitRepository<RateLimit> remoteCacheRateLimitRepository;
     private Disposable mergeSubscription;
 
+    /** How often the local counters are reconciled to the store (ms). Configured globally via the gateway service. */
+    private long flushIntervalMillis = DEFAULT_FLUSH_INTERVAL_MILLIS;
+
     public AsyncRateLimitRepository(final Vertx vertx) {
         this.sharedData = vertx.sharedData();
+    }
+
+    public void setFlushIntervalMillis(long flushIntervalMillis) {
+        this.flushIntervalMillis = flushIntervalMillis > 0 ? flushIntervalMillis : DEFAULT_FLUSH_INTERVAL_MILLIS;
     }
 
     public void initialize() {
@@ -57,7 +67,7 @@ public class AsyncRateLimitRepository implements RateLimitRepository<RateLimit> 
                 return state + 1;
             }
         )
-            .delay(5000, TimeUnit.MILLISECONDS)
+            .delay(flushIntervalMillis, TimeUnit.MILLISECONDS)
             .rebatchRequests(1)
             .filter(interval -> !keys.isEmpty())
             .concatMapCompletable(interval ->

--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitService.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitService.java
@@ -41,6 +41,11 @@ public class AsyncRateLimitService extends AbstractService {
     @Value("${services.ratelimit.enabled:true}")
     private boolean enabled;
 
+    // Global interval (ms) at which async (non-strict) local counters/buckets are reconciled to the store.
+    // Shared by both async repositories. Default preserves the original hardcoded 5s.
+    @Value("${services.ratelimit.async.flushInterval:5000}")
+    private long flushIntervalMillis;
+
     @Autowired
     private Vertx vertx;
 
@@ -69,6 +74,7 @@ public class AsyncRateLimitService extends AbstractService {
             beanFactory.autowireBean(asyncRateLimitRepository);
             asyncRateLimitRepository.setLocalCacheRateLimitRepository(localCacheRateLimitRepository);
             asyncRateLimitRepository.setRemoteCacheRateLimitRepository(rateLimitRepository);
+            asyncRateLimitRepository.setFlushIntervalMillis(flushIntervalMillis);
             asyncRateLimitRepository.initialize();
 
             LOGGER.info("Register the rate-limit service bridge for synchronous and asynchronous mode");
@@ -117,6 +123,7 @@ public class AsyncRateLimitService extends AbstractService {
             beanFactory.autowireBean(asyncTokenBucketRateLimitRepository);
             asyncTokenBucketRateLimitRepository.setLocalCacheTokenBucketRepository(localCacheTokenBucketRepository);
             asyncTokenBucketRateLimitRepository.setRemoteCacheTokenBucketRepository(tokenBucketRepository);
+            asyncTokenBucketRateLimitRepository.setFlushIntervalMillis(flushIntervalMillis);
             asyncTokenBucketRateLimitRepository.initialize();
 
             LOGGER.info("Register the token-bucket service bridge for synchronous and asynchronous mode");

--- a/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncTokenBucketRateLimitRepository.java
+++ b/gravitee-gateway-services-ratelimit/src/main/java/io/gravitee/gateway/services/ratelimit/AsyncTokenBucketRateLimitRepository.java
@@ -42,14 +42,24 @@ public class AsyncTokenBucketRateLimitRepository implements TokenBucketRateLimit
 
     private static final Long LOCK_TIMEOUT_MILLIS = 250L;
 
+    /** Default reconcile interval, preserved from the original hardcoded value. */
+    public static final long DEFAULT_FLUSH_INTERVAL_MILLIS = 5000L;
+
     private final Set<String> keys = new CopyOnWriteArraySet<>();
     private final SharedData sharedData;
     private LocalTokenBucketRateLimitRepository localCacheTokenBucketRepository;
     private TokenBucketRateLimitRepository<TokenBucket> remoteCacheTokenBucketRepository;
     private Disposable mergeSubscription;
 
+    /** How often the local deltas are reconciled to the store (ms). Configured globally via the gateway service. */
+    private long flushIntervalMillis = DEFAULT_FLUSH_INTERVAL_MILLIS;
+
     public AsyncTokenBucketRateLimitRepository(final Vertx vertx) {
         this.sharedData = vertx.sharedData();
+    }
+
+    public void setFlushIntervalMillis(long flushIntervalMillis) {
+        this.flushIntervalMillis = flushIntervalMillis > 0 ? flushIntervalMillis : DEFAULT_FLUSH_INTERVAL_MILLIS;
     }
 
     @Override
@@ -83,7 +93,7 @@ public class AsyncTokenBucketRateLimitRepository implements TokenBucketRateLimit
                 return state + 1;
             }
         )
-            .delay(5000, TimeUnit.MILLISECONDS)
+            .delay(flushIntervalMillis, TimeUnit.MILLISECONDS)
             .rebatchRequests(1)
             .filter(interval -> !keys.isEmpty())
             .concatMapCompletable(interval ->

--- a/gravitee-gateway-services-ratelimit/src/test/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitRepositoryTest.java
+++ b/gravitee-gateway-services-ratelimit/src/test/java/io/gravitee/gateway/services/ratelimit/AsyncRateLimitRepositoryTest.java
@@ -19,6 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.repository.ratelimit.api.RateLimitRepository;
@@ -70,6 +73,56 @@ public class AsyncRateLimitRepositoryTest {
     @AfterEach
     public void tearDown() {
         cut.clean();
+    }
+
+    @Test
+    public void reconciles_at_the_configured_flush_interval() throws InterruptedException {
+        RateLimit remote = new RateLimit(key);
+        remote.setCounter(11);
+        when(remoteCacheRateLimitRepository.incrementAndGet(anyString(), anyLong(), any())).thenReturn(
+            Single.just(new LocalRateLimit(remote))
+        );
+
+        AsyncRateLimitRepository fast = new AsyncRateLimitRepository(vertx);
+        fast.setRemoteCacheRateLimitRepository(remoteCacheRateLimitRepository);
+        fast.setLocalCacheRateLimitRepository(new LocalRateLimitRepository());
+        fast.setFlushIntervalMillis(500L); // much shorter than the default 5s
+        fast.initialize();
+        try {
+            RateLimit seed = new RateLimit(key);
+            seed.setCounter(1);
+            seed.setResetTime(Instant.now().plus(20, ChronoUnit.SECONDS).toEpochMilli());
+            fast.incrementAndGet(key, 1L, () -> seed).blockingGet();
+
+            Thread.sleep(1_500); // > configured 500ms, well under the 5s default
+
+            // With the hardcoded 5s delay the reconcile would not have fired yet; the configured 500ms must.
+            verify(remoteCacheRateLimitRepository, atLeastOnce()).incrementAndGet(anyString(), anyLong(), any());
+        } finally {
+            fast.clean();
+        }
+    }
+
+    @Test
+    public void non_positive_flush_interval_falls_back_to_the_default() throws InterruptedException {
+        AsyncRateLimitRepository zero = new AsyncRateLimitRepository(vertx);
+        zero.setRemoteCacheRateLimitRepository(remoteCacheRateLimitRepository);
+        zero.setLocalCacheRateLimitRepository(new LocalRateLimitRepository());
+        zero.setFlushIntervalMillis(0L); // invalid: a 0ms delay would busy-loop the reconcile at 100% CPU
+        zero.initialize();
+        try {
+            RateLimit seed = new RateLimit(key);
+            seed.setCounter(1);
+            seed.setResetTime(Instant.now().plus(20, ChronoUnit.SECONDS).toEpochMilli());
+            zero.incrementAndGet(key, 1L, () -> seed).blockingGet();
+
+            Thread.sleep(1_500); // well under the 5s default
+
+            // Clamped to the 5s default: no reconcile yet. A 0ms interval would have fired immediately and repeatedly.
+            verify(remoteCacheRateLimitRepository, never()).incrementAndGet(anyString(), anyLong(), any());
+        } finally {
+            zero.clean();
+        }
     }
 
     @Test

--- a/gravitee-gateway-services-ratelimit/src/test/java/io/gravitee/gateway/services/ratelimit/AsyncTokenBucketRateLimitRepositoryTest.java
+++ b/gravitee-gateway-services-ratelimit/src/test/java/io/gravitee/gateway/services/ratelimit/AsyncTokenBucketRateLimitRepositoryTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -149,5 +150,34 @@ class AsyncTokenBucketRateLimitRepositoryTest {
         LocalTokenBucket local = localCache.get(key).blockingGet();
         assertThat(local.getLocalConsumed()).isEqualTo(0); // delta cleared, not left to accumulate
         assertThat(local.getTokens()).isEqualTo(8); // local bucket untouched: a no-op store does not re-anchor it
+    }
+
+    @Test
+    void reconciles_at_the_configured_flush_interval() throws InterruptedException {
+        when(remoteCache.refillAndTryConsume(eq(key), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any())).thenReturn(
+            Single.just(new TokenBucketConsumeResult(true, 4, 0))
+        );
+        cut.setFlushIntervalMillis(500L); // much shorter than the default 5s
+        cut.initialize();
+
+        cut.refillAndTryConsume(key, 1, 1, 1_000L, 5, 1_000L, () -> new TokenBucket(key)).blockingGet();
+
+        Thread.sleep(1_500); // > configured 500ms, but well under the 5s default
+
+        // With the hardcoded 5s delay the reconcile would not have fired yet; the configured 500ms must.
+        verify(remoteCache, atLeastOnce()).refillAndTryConsume(eq(key), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any());
+    }
+
+    @Test
+    void non_positive_flush_interval_falls_back_to_the_default() throws InterruptedException {
+        cut.setFlushIntervalMillis(0L); // invalid: a 0ms delay would busy-loop the reconcile at 100% CPU
+        cut.initialize();
+
+        cut.refillAndTryConsume(key, 1, 1, 1_000L, 5, 1_000L, () -> new TokenBucket(key)).blockingGet();
+
+        Thread.sleep(1_500); // well under the 5s default
+
+        // Clamped to the 5s default: no reconcile yet. A 0ms interval would have fired immediately and repeatedly.
+        verify(remoteCache, never()).refillAndTryConsume(anyString(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), any());
     }
 }


### PR DESCRIPTION
## What

Makes the async (non-strict) flush/reconcile interval a **global** gateway property instead of the hardcoded 5s.

- New property **`services.ratelimit.async.flushInterval`** (milliseconds, **default 5000** — no behaviour change), read in `AsyncRateLimitService`.
- Applied to **both** async repositories: `AsyncRateLimitRepository` (counter: rate-limit / quota / spike-arrest) and `AsyncTokenBucketRateLimitRepository` (token-bucket). Each gets a settable `flushIntervalMillis` (default 5000) used in `initialize()` instead of the hardcoded `delay(5000, …)`.
- Single per-node scheduler design unchanged; the interval is shared infra tuning.

## Behaviour
- Unset → 5s (identical to today).
- Lower → tighter accuracy, more store round-trips. Higher → fewer round-trips/higher throughput, more cross-node over-admission/staleness.
- Only relevant in async mode (no effect in strict).

## Tests
TDD. New tests on both async repos: with a short interval (500ms) the reconcile fires within ~1.5s (vs the 5s default). `mvn -pl gravitee-gateway-services-ratelimit test` → 11 passed.

## Follow-up (separate PR)
Helm chart + gateway config reference (gravitee.yml) doc for the new property — in the gravitee-api-management monorepo.

Implements APIM-14500. Stacked on #143 (token-bucket async).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-wba-APIM-14500-async-flush-interval-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/5.0.0-wba-APIM-14500-async-flush-interval-SNAPSHOT/gravitee-ratelimit-parent-5.0.0-wba-APIM-14500-async-flush-interval-SNAPSHOT.zip)
  <!-- Version placeholder end -->
