### PR TITLE
fix(deps): update gravitee-apim.version to 4.12.0-milestone.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </parent>
 
     <properties>
-        <gravitee-apim.version>4.12.0-milestone.6-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.12.0-milestone.6</gravitee-apim.version>
         <gravitee-bom.version>8.3.63</gravitee-bom.version>
     </properties>
 


### PR DESCRIPTION
## What

Bump `gravitee-apim.version` from `4.12.0-milestone.6-SNAPSHOT` to the now-released **`4.12.0-milestone.6`**.

## Why

The token-bucket policy (`gravitee-policy-token-bucket-ratelimit`) compiles against `gravitee-apim-repository-api`, which provides the `TokenBucketRateLimitRepository` SPI. The `alpha` line was pinned to the `4.12.0-milestone.6-SNAPSHOT` while that interface was unreleased (see the release-coordination note on the epic). `4.12.0-milestone.6` is now released, so we drop the `-SNAPSHOT` to build against the stable artifact.

Relates to APIM-14481 (Token Bucket burst policy).

## Notes

- Single property change in the root `pom.xml`; no source changes.
- The `gravitee-bom.version` (8.3.63) is unchanged.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-wba-update-gravitee-apim-4-12-0-milestone-6-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/5.0.0-wba-update-gravitee-apim-4-12-0-milestone-6-SNAPSHOT/gravitee-ratelimit-parent-5.0.0-wba-update-gravitee-apim-4-12-0-milestone-6-SNAPSHOT.zip)
  <!-- Version placeholder end -->
