### PR TITLE
feat(token-bucket): token-budget mode (consume cost per request)

### DIFF
--- a/gravitee-policy-token-bucket-ratelimit/src/main/java/io/gravitee/policy/tokenbucket/TokenBucketRateLimitPolicy.java
+++ b/gravitee-policy-token-bucket-ratelimit/src/main/java/io/gravitee/policy/tokenbucket/TokenBucketRateLimitPolicy.java
@@ -24,6 +24,7 @@ import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
 import io.gravitee.policy.tokenbucket.configuration.TokenBucketRateLimitPolicyConfiguration;
 import io.gravitee.ratelimit.KeyFactory;
 import io.gravitee.ratelimit.PolicyRateLimitException;
+import io.gravitee.ratelimit.WeightResolver;
 import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
 import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitService;
 import io.gravitee.repository.ratelimit.model.TokenBucket;
@@ -120,8 +121,14 @@ public class TokenBucketRateLimitPolicy implements HttpPolicy {
         Single<Long> capacitySingle = configuration.getBurstCapacity() > 0
             ? Single.just(configuration.getBurstCapacity())
             : evalLong(ctx, configuration.getDynamicBurstCapacity());
+        Single<Long> weightSingle = WeightResolver.resolve(
+            ctx,
+            configuration.isBudget(),
+            configuration.getWeight(),
+            configuration.getDynamicWeight()
+        );
 
-        return Single.zip(keySingle, refillRateSingle, capacitySingle, Resolved::new).flatMapCompletable(resolved -> {
+        return Single.zip(keySingle, refillRateSingle, capacitySingle, weightSingle, Resolved::new).flatMapCompletable(resolved -> {
             long capacity = resolved.capacity();
             // Neither the static value nor a dynamic EL expression resolved to a positive number, so the
             // bucket would have zero capacity / refill and silently reject (or never hold) every request.
@@ -135,7 +142,7 @@ public class TokenBucketRateLimitPolicy implements HttpPolicy {
             }
             Single<TokenBucketConsumeResult> consume = service.refillAndTryConsume(
                 resolved.key(),
-                1,
+                resolved.weight(),
                 resolved.refillRate(),
                 refillPeriodMillis,
                 capacity,
@@ -177,7 +184,7 @@ public class TokenBucketRateLimitPolicy implements HttpPolicy {
         return ctx.getTemplateEngine().eval(expression, Long.class).defaultIfEmpty(0L);
     }
 
-    private record Resolved(String key, long refillRate, long capacity) {}
+    private record Resolved(String key, long refillRate, long capacity, long weight) {}
 
     private Completable applyResult(HttpBaseExecutionContext ctx, TokenBucketConsumeResult result, long capacity, long now) {
         if (configuration.isAddHeaders()) {

--- a/gravitee-policy-token-bucket-ratelimit/src/main/java/io/gravitee/policy/tokenbucket/configuration/TokenBucketRateLimitPolicyConfiguration.java
+++ b/gravitee-policy-token-bucket-ratelimit/src/main/java/io/gravitee/policy/tokenbucket/configuration/TokenBucketRateLimitPolicyConfiguration.java
@@ -75,4 +75,17 @@ public class TokenBucketRateLimitPolicyConfiguration implements PolicyConfigurat
     private String key;
 
     private boolean useKeyOnly;
+
+    /**
+     * Token-budget mode. When {@code false} (default) each request consumes {@code 1} token from the bucket.
+     * When {@code true} each request instead consumes its cost ({@link #weight} / {@link #dynamicWeight}), so
+     * the bucket is drained by accumulated token cost rather than a raw request count.
+     */
+    private boolean budget;
+
+    /** Static cost consumed per request when {@link #budget} is enabled. Used when {@code > 0}; otherwise {@link #dynamicWeight} is evaluated. */
+    private long weight;
+
+    /** EL expression for the per-request cost, evaluated when {@link #budget} is enabled and {@link #weight} is unset ({@code <= 0}). */
+    private String dynamicWeight;
 }

--- a/gravitee-policy-token-bucket-ratelimit/src/main/resources/schemas/schema-form.json
+++ b/gravitee-policy-token-bucket-ratelimit/src/main/resources/schemas/schema-form.json
@@ -44,6 +44,26 @@
                 "expression-language": true
             }
         },
+        "budget": {
+            "type": "boolean",
+            "default": false,
+            "title": "Token budget mode",
+            "description": "When enabled, each request consumes its cost (the weight below) from the bucket instead of 1 token, so the bucket is drained by accumulated token cost rather than a raw request count."
+        },
+        "weight": {
+            "type": "integer",
+            "title": "Cost per request (static)",
+            "description": "Static cost consumed per request when token budget mode is enabled (used if the value > 0).",
+            "minimum": 0
+        },
+        "dynamicWeight": {
+            "type": "string",
+            "title": "Cost per request (dynamic)",
+            "description": "Dynamic per-request cost (EL expression), used when token budget mode is enabled and the static cost = 0. For example reference a token-usage attribute set by an upstream policy. Defaults to 1 when blank.",
+            "x-schema-form": {
+                "expression-language": true
+            }
+        },
         "key": {
             "type": "string",
             "default": "",

--- a/gravitee-policy-token-bucket-ratelimit/src/test/java/io/gravitee/policy/tokenbucket/TokenBucketRateLimitPolicyTest.java
+++ b/gravitee-policy-token-bucket-ratelimit/src/test/java/io/gravitee/policy/tokenbucket/TokenBucketRateLimitPolicyTest.java
@@ -549,6 +549,122 @@ class TokenBucketRateLimitPolicyTest {
         );
     }
 
+    @Test
+    void should_consume_static_weight_when_budget_enabled(Vertx vertx, VertxTestContext testContext) {
+        // Budget mode on with a static cost of 10: each request drains 10 tokens from the bucket instead of 1.
+        configuration = TokenBucketRateLimitPolicyConfiguration.builder()
+            .refillRate(3)
+            .burstCapacity(300)
+            .budget(true)
+            .weight(10)
+            .addHeaders(false)
+            .key("test-key")
+            .useKeyOnly(true)
+            .build();
+        policy = new TokenBucketRateLimitPolicy(configuration);
+        when(service.refillAndTryConsume(any(), eq(10L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(
+            Single.just(new TokenBucketConsumeResult(true, 290, 1_000L))
+        );
+
+        vertx.runOnContext(v ->
+            policy
+                .onRequest(ctx)
+                .timeout(2, TimeUnit.SECONDS)
+                .doOnComplete(() ->
+                    verify(service).refillAndTryConsume(any(), eq(10L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())
+                )
+                .subscribe(new SubscribeAdapter(testContext))
+        );
+    }
+
+    @Test
+    void should_consume_dynamic_weight_from_el_when_budget_enabled(Vertx vertx, VertxTestContext testContext) {
+        // Budget mode on with no static cost: the per-request cost is resolved from the EL expression (e.g. a
+        // token-usage attribute set by an upstream policy) via async eval().
+        configuration = TokenBucketRateLimitPolicyConfiguration.builder()
+            .refillRate(3)
+            .burstCapacity(300)
+            .budget(true)
+            .dynamicWeight("{(42)}")
+            .addHeaders(false)
+            .key("test-key")
+            .useKeyOnly(true)
+            .build();
+        policy = new TokenBucketRateLimitPolicy(configuration);
+        when(templateEngine.eval("{(42)}", Long.class)).thenReturn(Maybe.just(42L));
+        when(service.refillAndTryConsume(any(), eq(42L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(
+            Single.just(new TokenBucketConsumeResult(true, 258, 1_000L))
+        );
+
+        vertx.runOnContext(v ->
+            policy
+                .onRequest(ctx)
+                .timeout(2, TimeUnit.SECONDS)
+                .doOnComplete(() ->
+                    verify(service).refillAndTryConsume(any(), eq(42L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())
+                )
+                .subscribe(new SubscribeAdapter(testContext))
+        );
+    }
+
+    @Test
+    void should_default_dynamic_weight_to_one_when_el_resolves_empty(Vertx vertx, VertxTestContext testContext) {
+        // Budget mode on but the cost expression resolves to nothing: rather than silently disabling
+        // enforcement (cost 0), the weight defaults to 1 so the request still counts.
+        configuration = TokenBucketRateLimitPolicyConfiguration.builder()
+            .refillRate(3)
+            .burstCapacity(300)
+            .budget(true)
+            .dynamicWeight("{#empty}")
+            .addHeaders(false)
+            .key("test-key")
+            .useKeyOnly(true)
+            .build();
+        policy = new TokenBucketRateLimitPolicy(configuration);
+        when(templateEngine.eval("{#empty}", Long.class)).thenReturn(Maybe.empty());
+        when(service.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(
+            Single.just(new TokenBucketConsumeResult(true, 299, 1_000L))
+        );
+
+        vertx.runOnContext(v ->
+            policy
+                .onRequest(ctx)
+                .timeout(2, TimeUnit.SECONDS)
+                .doOnComplete(() ->
+                    verify(service).refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())
+                )
+                .subscribe(new SubscribeAdapter(testContext))
+        );
+    }
+
+    @Test
+    void should_consume_one_when_budget_disabled_even_if_weight_set(Vertx vertx, VertxTestContext testContext) {
+        // The toggle gates the weight: with budget off, a configured weight is ignored and the request consumes 1.
+        configuration = TokenBucketRateLimitPolicyConfiguration.builder()
+            .refillRate(3)
+            .burstCapacity(300)
+            .budget(false)
+            .weight(10)
+            .addHeaders(false)
+            .key("test-key")
+            .useKeyOnly(true)
+            .build();
+        policy = new TokenBucketRateLimitPolicy(configuration);
+        when(service.refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())).thenReturn(
+            Single.just(new TokenBucketConsumeResult(true, 299, 1_000L))
+        );
+
+        vertx.runOnContext(v ->
+            policy
+                .onRequest(ctx)
+                .timeout(2, TimeUnit.SECONDS)
+                .doOnComplete(() ->
+                    verify(service).refillAndTryConsume(any(), eq(1L), eq(3L), eq(1_000L), eq(300L), eq(1_000L), eq(false), any())
+                )
+                .subscribe(new SubscribeAdapter(testContext))
+        );
+    }
+
     private record SubscribeAdapter(VertxTestContext testContext) implements CompletableObserver {
         @Override
         public void onSubscribe(@NonNull Disposable d) {}

--- a/gravitee-ratelimit-shared/src/main/java/io/gravitee/ratelimit/WeightResolver.java
+++ b/gravitee-ratelimit-shared/src/main/java/io/gravitee/ratelimit/WeightResolver.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ratelimit;
+
+import io.gravitee.gateway.reactive.api.context.http.HttpBaseExecutionContext;
+import io.reactivex.rxjava3.core.Single;
+
+/**
+ * Resolves how much a single invocation consumes ("weight") for the rate-limit, quota and token-bucket
+ * policies.
+ *
+ * <p>By default a request consumes {@code 1} (request-count rate limiting). When <em>token budget</em>
+ * mode is enabled, the weight is instead the <em>cost</em> of the request — e.g. the number of LLM tokens
+ * (or their priced equivalent) — so the limit is spent against accumulated cost rather than a raw request
+ * count. The cost is resolved exactly like {@code limit}/{@code refillRate}: a static positive value wins,
+ * otherwise the EL expression is evaluated per request (via async {@code eval()}, which supports deferred
+ * variables such as a token-usage attribute populated by an upstream policy).</p>
+ *
+ * <p>A blank/unresolved expression defaults to {@code 1} so enforcement is never silently disabled, and a
+ * negative result is clamped to {@code 0} (a free request).</p>
+ */
+public final class WeightResolver {
+
+    private WeightResolver() {}
+
+    /**
+     * @param budget        whether token-budget mode is enabled
+     * @param weight        static weight (cost) per invocation, used when {@code > 0}
+     * @param dynamicWeight EL expression for the weight (cost), evaluated when the static weight is unset
+     */
+    public static Single<Long> resolve(HttpBaseExecutionContext ctx, boolean budget, long weight, String dynamicWeight) {
+        if (!budget) {
+            return Single.just(1L);
+        }
+        if (weight > 0) {
+            return Single.just(weight);
+        }
+        if (dynamicWeight == null || dynamicWeight.isBlank()) {
+            return Single.just(1L);
+        }
+        return ctx
+            .getTemplateEngine()
+            .eval(dynamicWeight, Long.class)
+            .defaultIfEmpty(1L)
+            .map(w -> Math.max(0L, w));
+    }
+}


### PR DESCRIPTION
**Description**

Add a `budget` toggle to the token-bucket policy. When off (default) a
request consumes 1 token; when on it consumes its resolved cost
(`weight` static, else `dynamicWeight` EL), so the bucket drains by
accumulated token cost rather than request count. Resolution lives in
the new shared WeightResolver.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.0-feat-token-bucket-budget-mode-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-ratelimit-parent/5.1.0-feat-token-bucket-budget-mode-SNAPSHOT/gravitee-ratelimit-parent-5.1.0-feat-token-bucket-budget-mode-SNAPSHOT.zip)
  <!-- Version placeholder end -->
